### PR TITLE
test: カバレッジを計測し Codecov へ送信する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       # 1 つのチェックが失敗しても他のチェック結果を確認できるようにする
       fail-fast: false
       matrix:
-        task: ['format:check', 'lint', 'typecheck', 'test']
+        task: ['format:check', 'lint', 'typecheck']
     name: quality (${{ matrix.task }})
     steps:
       - uses: actions/checkout@v6
@@ -25,6 +25,27 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run ${{ matrix.task }}
+
+  # テスト + カバレッジ計測。結果を Codecov へ送信する。
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,7 +331,7 @@ npm run format:check  # Prettier の整形チェック (CI 用)
 npm run typecheck     # astro check による型チェック
 npm test              # Vitest を 1 回実行
 npm run test:watch    # Vitest ウォッチモード
-npm run test:coverage # カバレッジ付きで実行
+npm run test:coverage # カバレッジ付きで実行 (coverage/ に lcov / html を出力)
 npm run test:e2e      # Playwright (実ブラウザ E2E, e2e/ 配下)
 ```
 
@@ -340,6 +340,7 @@ npm run test:e2e      # Playwright (実ブラウザ E2E, e2e/ 配下)
 - **テスト (方針)**: リグレッションテストは可能な限りコードを広くカバーする。ブラウザ依存の不具合 (NG) を修正したときは、その再発防止として実ブラウザテストを追加する。
   - **単体/結合 (jsdom)**: Vitest + Testing Library。React アイランドや DOM ロジックの「動き」と「スタイリング」を `src/**/*.{test,spec}.{ts,tsx}` に配置。インライン `<script>` のロジックは `*.ts` モジュールへ分離してテスト可能にする (例: `SiteHeader.astro` の挙動は `siteHeaderNav.ts` に分離し `siteHeaderNav.test.ts` で検証)。
   - **E2E (実ブラウザ)**: Playwright (`playwright.config.ts` / `e2e/*.spec.ts`)。jsdom が扱えないレイアウト・重なり順 (z-index/stacking) など、描画を伴う回帰のみを対象とする。CI では `e2e` ジョブで `npx playwright install --with-deps chromium` 後に実行する。
+  - **カバレッジ (Codecov)**: `vitest.config.ts` の `coverage` 設定で v8 プロバイダを使い `coverage/lcov.info` を生成する。CI (`ci.yml`) の `coverage` ジョブが `npm run test:coverage` を実行し、`codecov/codecov-action` で Codecov へ送信する。トークンは GitHub Secrets の `CODECOV_TOKEN` を参照（公開リポジトリではトークンなしでも動作するが、設定推奨）。Codecov のステータスは導入初期のため `codecov.yml` で非ブロッキング（情報提供）にしてある。
 
 ## ビルド時の補助処理
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# Codecov 設定
+# カバレッジ計測を導入したばかりのため、ステータスは情報提供のみ (非ブロッキング) とする。
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: 'reach, diff, files'
+  require_changes: false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,8 +14,12 @@ export default getViteConfig({
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
-      // テスト本体や型定義などカバレッジ対象外のファイルを除外する。
-      exclude: ['src/**/*.{test,spec}.{ts,tsx}', 'src/types/**'],
+      // テスト本体・型定義・設定ファイル (テスト可能なロジックを持たない) を除外する。
+      exclude: [
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/types/**',
+        'src/content.config.ts',
+      ],
     },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,14 @@ export default getViteConfig({
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      // Codecov 連携用に lcov を出力。ローカル確認用に text / html も併設。
+      reporter: ['text', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      // テスト本体や型定義などカバレッジ対象外のファイルを除外する。
+      exclude: ['src/**/*.{test,spec}.{ts,tsx}', 'src/types/**'],
+    },
   },
 })


### PR DESCRIPTION
- vitest.config.ts に v8 カバレッジ設定を追加 (lcov / html / text)
- CI に coverage ジョブを新設し codecov-action で lcov を送信
- 導入初期のため codecov.yml でステータスを非ブロッキング化
- CLAUDE.md にカバレッジ/Codecov 連携を追記

https://claude.ai/code/session_0167MXGtXN1gP3ULWwBnmYhS