### PR TITLE
Remove page header gradient from BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,19 +40,7 @@ const currentPath = Astro.url.pathname
       ) : (
         <main class="flex grow flex-col overflow-auto">
           {/* grow で短いページでもフッターをビューポート下端へ押し下げる */}
-          <div
-            class:list={[
-              'grow',
-              'before:top-0',
-              'before:bg-gradient-to-b',
-              'before:from-primary',
-              'before:to-transparent',
-              'before:w-full',
-              'before:h-8',
-              'before:opacity-10',
-              'before:block',
-            ]}
-          >
+          <div class="grow">
             <slot />
           </div>
           <SiteFooter currentPath={currentPath} />


### PR DESCRIPTION
各ページのメインコンテンツ上部に表示されていた before: 疑似要素のグラデーション（from-primary to-transparent, h-8, opacity-10）を削除。

https://claude.ai/code/session_01VCuJA2fygkvDt7TTeeYCzX