### PR TITLE
レイアウトを標準的な sticky-footer に簡素化

### DIFF
--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -83,7 +83,7 @@ const ctaVariants = {
 ---
 
 <header
-  class="relative z-40 shrink-0 border-b border-primary/10 bg-base/95 shadow-sm backdrop-blur"
+  class="sticky top-0 z-40 shrink-0 border-b border-primary/10 bg-base/95 shadow-sm backdrop-blur"
 >
   <Container size="wide" class="flex items-center justify-between gap-4 py-3">
     <!-- ロゴ (遠山郷の重なる稜線 + 陽光 + コーラルの頂) -->

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -83,7 +83,7 @@ const ctaVariants = {
 ---
 
 <header
-  class="sticky top-0 z-40 shrink-0 border-b border-primary/10 bg-base/95 shadow-sm backdrop-blur"
+  class="sticky top-0 z-40 flex max-h-[100dvh] shrink-0 flex-col border-b border-primary/10 bg-base/95 shadow-sm backdrop-blur"
 >
   <Container size="wide" class="flex items-center justify-between gap-4 py-3">
     <!-- ロゴ (遠山郷の重なる稜線 + 陽光 + コーラルの頂) -->
@@ -192,7 +192,7 @@ const ctaVariants = {
     id="site-mobile-nav"
     data-mobile-nav
     hidden
-    class="border-t border-primary/10 bg-surface lg:hidden"
+    class="min-h-0 overflow-y-auto overscroll-contain border-t border-primary/10 bg-surface lg:hidden"
   >
     <Container size="wide" class="py-4">
       <!-- CTA (最優先導線を上部に) -->

--- a/src/components/siteHeaderNav.test.ts
+++ b/src/components/siteHeaderNav.test.ts
@@ -200,6 +200,19 @@ describe('initSiteHeaderNav — モバイルパネル', () => {
     expect(menuToggle.getAttribute('aria-expanded')).toBe('false')
   })
 
+  // リグレッション: スクロールして閉じたあと開き直すと、前回のスクロール
+  // 位置が残らず先頭に戻ること (直感に沿う初期状態で開く)。
+  it('開き直すとスクロール位置が先頭に戻る', () => {
+    const { menuToggle, mobilePanel } = setup()
+
+    fireClick(menuToggle, 1) // 開く
+    mobilePanel.scrollTop = 120 // 下までスクロールした状態を再現
+    fireClick(menuToggle, 1) // 閉じる
+    fireClick(menuToggle, 1) // 開き直す
+
+    expect(mobilePanel.scrollTop).toBe(0)
+  })
+
   it('Escape でモバイルパネルが閉じ、フォーカスが開閉ボタンへ戻る', () => {
     const { menuToggle, mobilePanel } = setup()
 

--- a/src/components/siteHeaderNav.ts
+++ b/src/components/siteHeaderNav.ts
@@ -25,6 +25,8 @@ export function initSiteHeaderNav(scope: ParentNode = document): void {
     const willOpen = panel.hasAttribute('hidden')
     panel.toggleAttribute('hidden', !willOpen)
     toggle.setAttribute('aria-expanded', String(willOpen))
+    // 開き直したときは前回のスクロール位置を引き継がず先頭に戻す
+    if (willOpen) panel.scrollTop = 0
   })
 
   // デスクトップドロップダウン (ディスクロージャー)

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,21 +30,22 @@ const currentPath = Astro.url.pathname
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class={fullscreen ? 'is-fullscreen' : undefined}>
     <SiteHeader currentPath={currentPath} />
     {
       fullscreen ? (
-        <main class="grow overflow-auto">
+        /* 確定高さの body 内で grow + min-h-0。子の h-full が高さを解決できる */
+        <main class="min-h-0 grow overflow-hidden">
           <slot />
         </main>
       ) : (
-        <main class="flex grow flex-col overflow-auto">
-          {/* grow で短いページでもフッターをビューポート下端へ押し下げる */}
-          <div class="grow">
+        /* main を grow させると、短いページでも SiteFooter が下端に収まる */
+        <Fragment>
+          <main class="grow">
             <slot />
-          </div>
+          </main>
           <SiteFooter currentPath={currentPath} />
-        </main>
+        </Fragment>
       )
     }
   </body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,7 @@ html {
  * (旧実装の「body 固定高 + main 内部スクロール + grow スペーサー」の入れ子を解消)
  */
 body {
+  min-height: 100vh; /* dvh 未対応ブラウザ向けフォールバック */
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -65,6 +66,7 @@ body {
  * 子コンポーネント (PdfViewer の h-full) が高さを解決できるようにする。
  */
 body.is-fullscreen {
+  height: 100vh; /* dvh 未対応ブラウザ向けフォールバック */
   height: 100dvh;
   overflow: hidden;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,8 +38,19 @@
   font-weight: var(--font-weight-light);
 }
 
+html {
+  /* sticky ヘッダーぶん、アンカー (#feed 等) のスクロール到達位置を下げる */
+  scroll-padding-top: 5rem;
+}
+
+/*
+ * 標準的な sticky-footer レイアウト。
+ * 文書フローのまま min-height で「最低でもビューポート高」を確保し、
+ * main を flex-grow させることで、短いページでもフッターが下端に収まる。
+ * (旧実装の「body 固定高 + main 内部スクロール + grow スペーサー」の入れ子を解消)
+ */
 body {
-  height: 100dvh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   background-color: var(--color-base);
@@ -47,4 +58,13 @@ body {
   font-family: var(--font-sans);
   text-align: justify;
   margin: 0;
+}
+
+/*
+ * 全画面ページ (PDF ビューワー等)。ビューポート高に固定して内部だけをスクロールさせ、
+ * 子コンポーネント (PdfViewer の h-full) が高さを解決できるようにする。
+ */
+body.is-fullscreen {
+  height: 100dvh;
+  overflow: hidden;
 }


### PR DESCRIPTION
body 固定高 + main 内部スクロール (overflow-auto) + grow スペーサー div
という入れ子 flexbox を、文書フロー + min-height:100dvh の標準的な
sticky-footer へ置き換え。main を grow させ、SiteFooter を body 直下の
兄弟に移すことで、短いページでもフッターが下端に収まる。

- 文書スクロールに戻るため SiteHeader を sticky top-0 にして常時表示を維持
  (どのページからも参加/寄付 CTA に届く方針を継続)
- html に scroll-padding-top を追加し、sticky ヘッダーぶんアンカー
  (#feed 等) の到達位置を補正
- PDF ビューワー (fullscreen) は子の h-full が高さを解決できるよう
  body.is-fullscreen で確定高さ + overflow:hidden に切り替え