### PR TITLE
style: 本文の行間を 1.7 に設定して間伸び感を解消

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,6 +57,7 @@ body {
   background-color: var(--color-base);
   color: var(--color-body);
   font-family: var(--font-sans);
+  line-height: 1.7;
   text-align: justify;
   margin: 0;
 }


### PR DESCRIPTION
## Summary

- `src/styles/global.css` の `body` に `line-height: 1.7` を追加
- ブラウザ/Tailwind のデフォルト（1.5〜1.75 程度）より締まった値で、日本語本文の間伸び感を解消
- 見出しやコンポーネント個別の `leading-*` クラスには影響しない（継承のみ）

## Test plan

- [ ] CI (lint / format / typecheck / test / build) がすべて green になること
- [ ] 各ページの本文テキストが適切な行間で表示されること
- [ ] モバイル・デスクトップ両方で読みやすさが維持されていること

https://claude.ai/code/session_01Src4ZYdpeBhsAbAgQvrAbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Src4ZYdpeBhsAbAgQvrAbD)_