### PR TITLE
Add NewsCta component with interval-based insertion in article lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,10 @@ tohyamago/
 │   │   ├── Card.astro          # 共通 UI プリミティブ (カード)
 │   │   ├── Container.astro     # 共通 UI プリミティブ (コンテナ幅)
 │   │   ├── SectionHeading.astro# 共通 UI プリミティブ (▲ 見出し)
-│   │   ├── Posts.astro         # Content Collection から記事を描画
+│   │   ├── Posts.astro         # Content Collection から記事を描画 (ctaEvery で記事間に NewsCta を挿入)
+│   │   ├── NewsCta.astro        # 「次は、あなたの番です」CTA (記事間 compact / 末尾 full で再利用)
+│   │   ├── postCtaLayout.ts     # 記事間 CTA の挿入位置を決める純粋関数
+│   │   ├── postCtaLayout.test.ts# postCtaLayout のテスト (Vitest)
 │   │   └── PdfViewer.tsx       # PDF.js Express ラッパー (React, client:only)
 │   ├── content.config.ts       # Content Collection スキーマ (posts / crops / events)
 │   ├── content/
@@ -142,6 +145,7 @@ tohyamago/
 #### 近況 / 予定の扱い
 
 - **近況アーカイブは `/news`（`news.astro`）に集約**し、`Posts.astro` で全記事を描画する。トップ（`index.astro`）は記事が長くなりすぎないよう **最新数件のダイジェスト（`<Posts limit={3} />`）のみ**を載せ、「これまでの活動をもっと見る」CTA で `/news` へ誘導する。ヘッダーナビ「近況」も `/news` を指す。
+- 全記事一覧（130 件超）は縦に非常に長く、末尾の「次は、あなたの番です」CTA に辿り着けない問題があったため、`<Posts ctaEvery={12} />` で **一定間隔（12 件ごと）に `NewsCta`（compact）を差し込み**、どこまで読んでも参加・支援への一歩に出会えるようにしている。挿入位置は純粋関数 `postCtaLayout.ts`（`ctaPositions`）が決定し、最終記事直後は末尾の本 CTA（`NewsCta` full）と重複しないよう除外する。
 - トップ末尾の近況ダイジェストには `id="feed"` を残し、旧 `/#feed` ブックマークの着地点として後方互換を保つ（新規リンクは `/news` を使う）。
 - かつての「近況 / 予定」タブ（旧 `HomeTabs.tsx`）は廃止。情報量の薄かった「予定」タブは **`/calendar`（農作業カレンダー）と、トップの「今月の活動」プレビュー（`homeTasks.ts`）へ発展的に統合**した。activo の募集 CTA は `/join` に集約している。
 

--- a/src/components/NewsCta.astro
+++ b/src/components/NewsCta.astro
@@ -1,0 +1,67 @@
+---
+/**
+ * NewsCta — 近況ページの「次は、あなたの番です」CTA。
+ * 記事一覧の合間 (compact) と、ページ末尾 (full) の両方で使い回す。
+ * compact は記事カードに馴染む軽量バナーで、読み進める途中でも
+ * 参加・支援への一歩を促す。full は読了後の本 CTA。
+ */
+import Card from '~/components/Card.astro'
+import SectionHeading from '~/components/SectionHeading.astro'
+import Button from '~/components/Button.astro'
+
+interface Props {
+  compact?: boolean
+  class?: string
+}
+
+const { compact = false, class: className = '' } = Astro.props
+---
+
+{
+  compact ? (
+    <Card
+      as="aside"
+      class:list={[
+        'bg-gradient-to-br from-sunlight-soft/50 to-surface px-6 py-7 text-center',
+        className,
+      ]}
+    >
+      <p
+        class="flex items-center justify-center gap-2 font-serif text-lg font-medium text-primary
+               before:text-xs before:text-accent-strong before:content-['▲']"
+      >
+        次は、あなたの番です
+      </p>
+      <p class="mx-auto mt-2 max-w-md text-sm leading-relaxed text-body">
+        気になる活動があれば、ぜひ現地へ。初めての方も大歓迎です。
+      </p>
+      <div class="mt-5 flex flex-wrap justify-center gap-3">
+        <Button href="/join">活動に参加する</Button>
+        <Button href="/support" variant="outline">
+          活動を支える
+        </Button>
+      </div>
+    </Card>
+  ) : (
+    <Card
+      as="section"
+      class:list={[
+        'bg-gradient-to-br from-sunlight-soft/60 to-surface px-6 py-10 text-center md:px-12',
+        className,
+      ]}
+    >
+      <SectionHeading as="h2" align="center" class="mb-4">
+        次は、あなたの番です
+      </SectionHeading>
+      <p class="mx-auto max-w-xl leading-loose text-body">
+        記事の一場面に「いいな」と思ったら、ぜひ現地へ。初めての方も大歓迎です。あなたの参加が、この物語の続きになります。
+      </p>
+      <div class="mt-8 flex flex-wrap justify-center gap-3">
+        <Button href="/join">活動に参加する</Button>
+        <Button href="/support" variant="outline">
+          活動を支える
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/Posts.astro
+++ b/src/components/Posts.astro
@@ -2,19 +2,27 @@
 import { Image } from 'astro:assets'
 import { getCollection, render } from 'astro:content'
 import Card from '~/components/Card.astro'
+import NewsCta from '~/components/NewsCta.astro'
+import { ctaPositions } from '~/components/postCtaLayout'
 
 interface Props {
   /** 表示件数の上限。未指定なら全件 (近況アーカイブ /news 用)。トップは最新数件のダイジェスト。 */
   limit?: number
+  /** 記事 ctaEvery 件ごとに「次は、あなたの番です」CTA を差し込む (近況アーカイブ用)。0/未指定で無効。 */
+  ctaEvery?: number
 }
 
-const { limit } = Astro.props
+const { limit, ctaEvery = 0 } = Astro.props
 
 const sorted = (await getCollection('posts')).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 )
 // limit は 0 も有効な境界値 (0 件) として扱うため、undefined 判定で全件と区別する。
 const posts = limit === undefined ? sorted : sorted.slice(0, limit)
+
+// 一覧が長い近況アーカイブでは、一定間隔で CTA を再登場させて
+// 「末尾まで読まないと参加導線に出会えない」状態を防ぐ。
+const ctaAfter = ctaPositions(posts.length, ctaEvery)
 
 const dateFormat = (date: Date) => {
   const year = date.getFullYear()
@@ -34,22 +42,25 @@ const rendered = await Promise.all(
 
 <section class="mx-auto grid w-full max-w-2xl gap-5 px-4 sm:px-6">
   {
-    rendered.map(({ post, Content }) => (
-      <Card as="article" hover class="px-6 pt-4 pb-5">
-        <time class="mb-2 block font-mono text-xs font-medium text-accent-strong">
-          {dateFormat(post.data.date)}
-        </time>
-        <div class="post-body text-justify leading-relaxed text-body">
-          <Content />
-        </div>
-        {post.data.images.map((img) => (
-          <Image
-            src={img}
-            alt=""
-            class="mt-4 aspect-video w-full rounded-xl border border-primary/10 object-cover saturate-[0.85]"
-          />
-        ))}
-      </Card>
+    rendered.map(({ post, Content }, index) => (
+      <Fragment>
+        <Card as="article" hover class="px-6 pt-4 pb-5">
+          <time class="mb-2 block font-mono text-xs font-medium text-accent-strong">
+            {dateFormat(post.data.date)}
+          </time>
+          <div class="post-body text-justify leading-relaxed text-body">
+            <Content />
+          </div>
+          {post.data.images.map((img) => (
+            <Image
+              src={img}
+              alt=""
+              class="mt-4 aspect-video w-full rounded-xl border border-primary/10 object-cover saturate-[0.85]"
+            />
+          ))}
+        </Card>
+        {ctaAfter.has(index) && <NewsCta compact />}
+      </Fragment>
     ))
   }
 </section>

--- a/src/components/postCtaLayout.test.ts
+++ b/src/components/postCtaLayout.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { ctaPositions } from './postCtaLayout'
+
+describe('ctaPositions', () => {
+  it('every 件ごとの記事直後に CTA を挿入する', () => {
+    // 36 件・間隔 12 → 12,24 件目の直後 (index 11, 23)
+    expect([...ctaPositions(36, 12)]).toEqual([11, 23])
+  })
+
+  it('最終記事の直後には挿入しない (末尾の本 CTA と重複させない)', () => {
+    // 24 件・間隔 12 → 本来 index 11, 23 だが 23 は最終記事なので除外
+    expect([...ctaPositions(24, 12)]).toEqual([11])
+  })
+
+  it('記事数が間隔以下なら挿入しない', () => {
+    expect([...ctaPositions(12, 12)]).toEqual([])
+    expect([...ctaPositions(5, 12)]).toEqual([])
+  })
+
+  it('every が 0 以下なら常に空 (無効化)', () => {
+    expect([...ctaPositions(100, 0)]).toEqual([])
+    expect([...ctaPositions(100, -3)]).toEqual([])
+  })
+
+  it('記事 0 件でも例外を投げず空を返す', () => {
+    expect([...ctaPositions(0, 12)]).toEqual([])
+  })
+})

--- a/src/components/postCtaLayout.ts
+++ b/src/components/postCtaLayout.ts
@@ -1,0 +1,21 @@
+/**
+ * 近況アーカイブ (/news) で記事の合間に「次は、あなたの番です」CTA を
+ * 差し込む位置を決める純粋関数。記事一覧が縦に長くなりすぎて末尾の CTA に
+ * 辿り着けない問題への対策として、一定間隔で CTA を再登場させる。
+ *
+ * - `every` 件ごとに記事の直後へ CTA を 1 つ挿入する。
+ * - 最終記事の直後 (index === total - 1) には挿入しない。
+ *   ページ末尾には本 CTA を別途置くため、重複を避ける。
+ *
+ * @param total 記事の総数
+ * @param every CTA を挟む間隔 (記事数)。0 以下なら挿入しない。
+ * @returns CTA を直後に表示する記事インデックス (0 始まり) の Set
+ */
+export function ctaPositions(total: number, every: number): Set<number> {
+  const positions = new Set<number>()
+  if (every <= 0) return positions
+  for (let i = every - 1; i < total - 1; i += every) {
+    positions.add(i)
+  }
+  return positions
+}

--- a/src/pages/news.astro
+++ b/src/pages/news.astro
@@ -2,9 +2,8 @@
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import Container from '~/components/Container.astro'
 import SectionHeading from '~/components/SectionHeading.astro'
-import Button from '~/components/Button.astro'
-import Card from '~/components/Card.astro'
 import Posts from '~/components/Posts.astro'
+import NewsCta from '~/components/NewsCta.astro'
 
 // 近況アーカイブ。トップには最新数件のダイジェストのみを載せ、全件はこのページへ集約する。
 ---
@@ -31,23 +30,11 @@ import Posts from '~/components/Posts.astro'
 
   <Container class="py-12 md:py-16">
     <SectionHeading as="h2" class="mb-8 sr-only">活動の記録</SectionHeading>
-    <Posts />
+    <!-- 記事が 130 件超と長いため、一定間隔で CTA を差し込み、
+         どこまで読んでも参加・支援への一歩に出会えるようにする。 -->
+    <Posts ctaEvery={12} />
 
-    <!-- 次の一歩 CTA: 読んだあと参加・支援へ送り出す (情報設計の原則「各ページに CTA」) -->
-    <Card
-      as="section"
-      class="mt-14 bg-gradient-to-br from-sunlight-soft/60 to-surface px-6 py-10 text-center md:px-12"
-    >
-      <SectionHeading as="h2" align="center" class="mb-4"
-        >次は、あなたの番です</SectionHeading
-      >
-      <p class="mx-auto max-w-xl leading-loose text-body">
-        記事の一場面に「いいな」と思ったら、ぜひ現地へ。初めての方も大歓迎です。あなたの参加が、この物語の続きになります。
-      </p>
-      <div class="mt-8 flex flex-wrap justify-center gap-3">
-        <Button href="/join">活動に参加する</Button>
-        <Button href="/support" variant="outline">活動を支える</Button>
-      </div>
-    </Card>
+    <!-- 次の一歩 CTA: 読了後に参加・支援へ送り出す本 CTA (情報設計の原則「各ページに CTA」) -->
+    <NewsCta class="mt-14" />
   </Container>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Introduces a reusable "次は、あなたの番です" (Next, it's your turn) CTA component that appears both inline within article lists and as a full-width section at page end. Solves the problem of long article archives (130+ posts) where readers never reach the footer CTA by strategically inserting compact CTAs at regular intervals.

## Key Changes

- **New `NewsCta.astro` component**: Dual-mode CTA with `compact` prop
  - `compact={true}`: Lightweight banner styled to blend with article cards, used for mid-list insertion
  - `compact={false}` (default): Full-width section with larger heading, used as page-end CTA
  - Both modes share identical call-to-action buttons ("参加する" / "活動を支える")

- **New `postCtaLayout.ts` utility**: Pure function `ctaPositions(total, every)` that calculates insertion points
  - Returns a `Set<number>` of article indices after which to insert CTAs
  - Inserts every `every` articles (e.g., every 12 posts)
  - Excludes the final article to avoid duplication with the footer CTA
  - Handles edge cases: zero/negative `every` (disabled), article count ≤ interval, empty lists

- **Updated `Posts.astro`**: 
  - Added `ctaEvery` prop to enable interval-based CTA insertion
  - Uses `ctaPositions()` to determine insertion points
  - Wraps each article + conditional CTA in a `<Fragment>` for proper rendering

- **Updated `news.astro`**:
  - Replaced inline CTA markup with `<NewsCta class="mt-14" />`
  - Passes `ctaEvery={12}` to `<Posts />` to insert compact CTAs every 12 articles
  - Cleaner separation of concerns: CTA logic moved to component

- **Added `postCtaLayout.test.ts`**: Comprehensive Vitest suite covering
  - Correct interval calculation
  - Final article exclusion
  - Edge cases (empty lists, disabled intervals, short lists)

- **Updated `CLAUDE.md`**: Documented new components and the CTA insertion strategy

## Implementation Details

- The `ctaPositions` function uses a simple loop: `for (let i = every - 1; i < total - 1; i += every)` to generate indices, ensuring the last article is never included
- `NewsCta` reuses existing components (`Card`, `SectionHeading`, `Button`) for consistency
- The compact variant uses a gradient background (`from-sunlight-soft/50`) and smaller text to maintain visual hierarchy within article lists
- No breaking changes: `ctaEvery` defaults to 0 (disabled), so existing usage of `<Posts />` remains unchanged

https://claude.ai/code/session_01RK3vxLzpZ1bHzJmTZw1W4n