### PR TITLE
始まり物語のヒーローと挿絵をライトノベル風 SVG アートに刷新

### DIFF
--- a/src/components/StoryArt.test.tsx
+++ b/src/components/StoryArt.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import StoryArt from './StoryArt'
+
+describe('StoryArt', () => {
+  it('SVG を描画する (viewBox は 16:9 相当)', () => {
+    const { container } = render(<StoryArt scene="hero" />)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg).toHaveAttribute('viewBox', '0 0 800 450')
+    // 背景として敷き詰められるよう slice で覆う
+    expect(svg).toHaveAttribute('preserveAspectRatio', 'xMidYMid slice')
+  })
+
+  it('title を与えると role="img" + aria-label になる', () => {
+    const { container } = render(
+      <StoryArt scene="hero" title="谷を見上げる人影" />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('role', 'img')
+    expect(svg).toHaveAttribute('aria-label', '谷を見上げる人影')
+    expect(svg).not.toHaveAttribute('aria-hidden')
+  })
+
+  it('title が無ければ装飾として aria-hidden になる', () => {
+    const { container } = render(<StoryArt scene="field" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('aria-hidden', 'true')
+    expect(svg).not.toHaveAttribute('role')
+  })
+
+  it('シーンごとにグラデーション ID が分かれ、別ページで衝突しない', () => {
+    const { container } = render(<StoryArt scene="winter" />)
+    expect(container.querySelector('#art-winter-sky')).not.toBeNull()
+    expect(container.querySelector('#art-field-sky')).toBeNull()
+  })
+
+  it('冬のシーンだけ雪化粧 (白い頂) が描かれる', () => {
+    const { container: winter } = render(<StoryArt scene="winter" />)
+    const { container: field } = render(<StoryArt scene="field" />)
+    // 雪は白い <g> 配下の polygon。冬は描画され、夏の畑シーンには無い。
+    const snowPolys = (c: HTMLElement) =>
+      c.querySelectorAll('g[fill="#ffffff"] polygon')
+    expect(snowPolys(winter).length).toBeGreaterThan(0)
+    expect(snowPolys(field).length).toBe(0)
+  })
+
+  it('未知のシーンは hero にフォールバックする', () => {
+    // @ts-expect-error 故意に不正なシーンを渡す
+    const { container } = render(<StoryArt scene="unknown" />)
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/src/components/StoryArt.tsx
+++ b/src/components/StoryArt.tsx
@@ -1,0 +1,355 @@
+/**
+ * StoryArt — 「遠山郷との始まり」(ライトノベル) 専用のベクター挿絵。
+ *
+ * 読み物のトーンに合わせ、実写ではなく手描き風の SVG アートで情景を描く。
+ * すべてのシーンは「空 → 遠/中/近の山並み → 段々畑」という共通の構図言語を
+ * 共有しつつ、配色 (時間帯・季節) と前景のモチーフだけを差し替える。これにより
+ * ページを送るたびに「同じ谷の、少しずつ違う表情」が現れる連続性を持たせている。
+ *
+ * 静的な装飾画像のため hydration は不要。Astro からも React 島 (StoryReader)
+ * からも、同じコンポーネントとして再利用できる。
+ */
+
+export type StoryScene =
+  | 'hero'
+  | 'winter'
+  | 'notice'
+  | 'seed'
+  | 'field'
+  | 'gather'
+  | 'dawn'
+
+interface Palette {
+  /** 空のグラデーション (上→下の 3 段) */
+  sky: [string, string, string]
+  /** 太陽/月の本体色 */
+  sun: string
+  /** 太陽まわりの光暈 */
+  glow: string
+  /** 太陽の位置 (viewBox 800x450 基準) と大きさ */
+  sunPos: [number, number, number]
+  /** 山並み 遠 / 中 / 近 の色 */
+  far: string
+  mid: string
+  near: string
+  /** 段々畑の基調色とコントラスト色 */
+  field: string
+  fieldAlt: string
+  /** 雪化粧するか (冬) */
+  snow: boolean
+  /** 前景モチーフ */
+  motif:
+    | 'figure'
+    | 'travelers'
+    | 'hut'
+    | 'sprout'
+    | 'rows'
+    | 'lanterns'
+    | 'path'
+}
+
+// 共有する山の稜線 (全シーン同じシルエットを使い、色だけ変える)。
+const RIDGE_FAR =
+  '0,182 110,120 210,172 320,108 430,166 540,118 660,170 760,124 800,150 800,460 0,460'
+const RIDGE_MID =
+  '0,242 130,172 250,232 370,158 480,226 600,164 720,228 800,192 800,460 0,460'
+const RIDGE_NEAR =
+  '0,302 150,236 300,300 450,228 600,300 750,246 800,276 800,460 0,460'
+
+const SCENES: Record<StoryScene, Palette> = {
+  // キービジュアル: 陽光のさす谷を、ひとりの人影が見上げる。
+  hero: {
+    sky: ['#cdeefb', '#e9f7ee', '#fff7e2'],
+    sun: '#ffc24b',
+    glow: '#ffe6ac',
+    sunPos: [600, 120, 46],
+    far: '#9fcfd6',
+    mid: '#54a585',
+    near: '#2f8a64',
+    field: '#1f855f',
+    fieldAlt: '#44b08c',
+    snow: false,
+    motif: 'figure',
+  },
+  // プロローグ「冬の、秘境へ」: 冷たい青、雪化粧、谷へ向かう人々。
+  winter: {
+    sky: ['#dceaf2', '#eef5f8', '#ffffff'],
+    sun: '#f6e7c4',
+    glow: '#ffffff',
+    sunPos: [210, 110, 40],
+    far: '#b7cdd8',
+    mid: '#9db4c1',
+    near: '#c6d4dc',
+    field: '#e6edf1',
+    fieldAlt: '#cfdae1',
+    snow: true,
+    motif: 'travelers',
+  },
+  // 第一話「一枚の貼り紙」: 朝の伝承館と、貼り紙の掲示板。
+  notice: {
+    sky: ['#ffe8cf', '#fff2dd', '#fffaf0'],
+    sun: '#ffb36b',
+    glow: '#ffd9a8',
+    sunPos: [150, 116, 42],
+    far: '#a9c0b2',
+    mid: '#6fa085',
+    near: '#4d8a6a',
+    field: '#7a9c5e',
+    fieldAlt: '#9bb673',
+    snow: false,
+    motif: 'hut',
+  },
+  // 第二話「二度芋は、二度芋だ」: 土の畝と、芽吹き。
+  seed: {
+    sky: ['#eaf3df', '#f4f6e6', '#fff8e6'],
+    sun: '#ffd36b',
+    glow: '#ffe6ac',
+    sunPos: [620, 128, 40],
+    far: '#bcae8e',
+    mid: '#9c8a5e',
+    near: '#7d6a3e',
+    field: '#8a5a32',
+    fieldAlt: '#a6713f',
+    snow: false,
+    motif: 'sprout',
+  },
+  // 第三話「はじめての農作業」: 青空のもと、芽の並ぶ段々畑。
+  field: {
+    sky: ['#cdeafb', '#e6f6ec', '#fbfbe6'],
+    sun: '#ffc24b',
+    glow: '#ffe6ac',
+    sunPos: [410, 96, 44],
+    far: '#8fc6cf',
+    mid: '#54a585',
+    near: '#2f8a64',
+    field: '#1f855f',
+    fieldAlt: '#44b08c',
+    snow: false,
+    motif: 'rows',
+  },
+  // 第四話「通うようになった理由」: 夕暮れの灯りと、ぬくもり。
+  gather: {
+    sky: ['#ffd2a8', '#ff9e6b', '#f06b4b'],
+    sun: '#ffb84b',
+    glow: '#ffd98c',
+    sunPos: [600, 150, 50],
+    far: '#8a7a82',
+    mid: '#6a5560',
+    near: '#4a3a44',
+    field: '#3a2e36',
+    fieldAlt: '#5a4750',
+    snow: false,
+    motif: 'lanterns',
+  },
+  // エピローグ「活動は、続いていく」: 朝焼けと、谷を上る一本道。
+  dawn: {
+    sky: ['#ffdca8', '#ffeccf', '#eaf6ee'],
+    sun: '#ff8a5b',
+    glow: '#ffd9a8',
+    sunPos: [400, 118, 48],
+    far: '#a9c6cf',
+    mid: '#5aa585',
+    near: '#2f8a64',
+    field: '#1f855f',
+    fieldAlt: '#44b08c',
+    snow: false,
+    motif: 'path',
+  },
+}
+
+/** 人影シルエット (光の谷を見上げる旅人)。 */
+function Person(x: number, y: number, s: number, color: string) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${s})`} fill={color}>
+      <circle cx="0" cy="-26" r="6" />
+      <path d="M-7 -20 Q0 -24 7 -20 L9 2 Q0 6 -9 2 Z" />
+      <rect x="-7" y="0" width="5" height="16" rx="2" />
+      <rect x="2" y="0" width="5" height="16" rx="2" />
+    </g>
+  )
+}
+
+export default function StoryArt({
+  scene = 'hero',
+  className = '',
+  title,
+}: {
+  scene?: StoryScene
+  className?: string
+  /** 与えると role="img" + aria-label になる (装飾のみなら省略して aria-hidden に) */
+  title?: string
+}) {
+  const p = SCENES[scene] ?? SCENES.hero
+  const id = `art-${scene}`
+  const [sx, sy, sr] = p.sunPos
+
+  // 段々畑: 下半分に、ゆるく波打つ等高線のバンドを重ねる。
+  const bands = Array.from({ length: 5 }, (_, i) => {
+    const top = 318 + i * 27
+    const fill = i % 2 === 0 ? p.field : p.fieldAlt
+    return { top, fill, i }
+  })
+
+  return (
+    <svg
+      viewBox="0 0 800 450"
+      preserveAspectRatio="xMidYMid slice"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      role={title ? 'img' : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+    >
+      <defs>
+        <linearGradient id={`${id}-sky`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={p.sky[0]} />
+          <stop offset="55%" stopColor={p.sky[1]} />
+          <stop offset="100%" stopColor={p.sky[2]} />
+        </linearGradient>
+        <radialGradient id={`${id}-glow`}>
+          <stop offset="0%" stopColor={p.glow} stopOpacity="0.95" />
+          <stop offset="100%" stopColor={p.glow} stopOpacity="0" />
+        </radialGradient>
+      </defs>
+
+      {/* 空 */}
+      <rect x="0" y="0" width="800" height="450" fill={`url(#${id}-sky)`} />
+
+      {/* 太陽 (光暈つき) */}
+      <circle cx={sx} cy={sy} r={sr * 2.4} fill={`url(#${id}-glow)`} />
+      <circle cx={sx} cy={sy} r={sr} fill={p.sun} />
+
+      {/* 山並み: 遠 → 中 → 近 */}
+      <polygon points={RIDGE_FAR} fill={p.far} opacity="0.85" />
+      <polygon points={RIDGE_MID} fill={p.mid} opacity="0.92" />
+      <polygon points={RIDGE_NEAR} fill={p.near} />
+
+      {/* 雪化粧 (冬のみ): 主要な稜線の頂に白を載せる */}
+      {p.snow && (
+        <g fill="#ffffff" opacity="0.9">
+          <polygon points="320,108 300,140 345,140" />
+          <polygon points="540,118 520,150 562,150" />
+          <polygon points="370,158 352,186 392,186" />
+        </g>
+      )}
+
+      {/* 段々畑 (共通の構図) */}
+      {bands.map(({ top, fill, i }) => (
+        <path
+          key={i}
+          d={`M0 ${top} Q200 ${top - 12} 400 ${top} T800 ${top} L800 460 L0 460 Z`}
+          fill={fill}
+          opacity={0.96 - i * 0.04}
+        />
+      ))}
+      {/* 等高線 (畑のうね) */}
+      {bands.map(({ top, i }) => (
+        <path
+          key={`l-${i}`}
+          d={`M0 ${top} Q200 ${top - 12} 400 ${top} T800 ${top}`}
+          fill="none"
+          stroke="#ffffff"
+          strokeOpacity="0.18"
+          strokeWidth="1.5"
+        />
+      ))}
+
+      {/* ── 前景モチーフ (シーンごと) ── */}
+
+      {/* 旅人ひとり (キービジュアル) */}
+      {p.motif === 'figure' && Person(360, 360, 1.5, '#2c2a26')}
+
+      {/* 谷へ向かう人々 (プロローグ) */}
+      {p.motif === 'travelers' && (
+        <g>
+          {Person(330, 356, 1.1, '#3e3a35')}
+          {Person(372, 366, 1.3, '#2c2a26')}
+          {Person(414, 360, 1.0, '#4a463f')}
+        </g>
+      )}
+
+      {/* 伝承館と掲示板 (第一話) */}
+      {p.motif === 'hut' && (
+        <g>
+          {/* 民家 */}
+          <rect x="470" y="296" width="120" height="74" fill="#6b4a32" />
+          <polygon points="460,296 530,256 600,296" fill="#4a3322" />
+          <rect x="500" y="330" width="26" height="40" fill="#2c2a26" />
+          <rect x="548" y="320" width="26" height="22" fill="#cfe3ea" />
+          {/* 掲示板に一枚の貼り紙 */}
+          <rect x="300" y="318" width="8" height="54" fill="#5a4632" />
+          <rect x="356" y="318" width="8" height="54" fill="#5a4632" />
+          <rect x="294" y="300" width="76" height="34" rx="3" fill="#3a2c20" />
+          <rect
+            x="306"
+            y="306"
+            width="40"
+            height="22"
+            rx="1"
+            fill="#fffdf7"
+            transform="rotate(-3 326 317)"
+          />
+        </g>
+      )}
+
+      {/* 土の畝と芽吹き (第二話) */}
+      {p.motif === 'sprout' && (
+        <g>
+          {[0, 1, 2].map((r) =>
+            [0, 1, 2, 3, 4, 5].map((c) => (
+              <g
+                key={`${r}-${c}`}
+                transform={`translate(${150 + c * 90} ${350 + r * 28})`}
+              >
+                <path
+                  d="M0 0 C-2 -14 -10 -16 -12 -22 C-4 -22 -1 -16 0 -10 C1 -16 4 -22 12 -22 C10 -16 2 -14 0 0 Z"
+                  fill="#3f7a3f"
+                />
+              </g>
+            )),
+          )}
+        </g>
+      )}
+
+      {/* 苗の並ぶ畑 (第三話) */}
+      {p.motif === 'rows' && (
+        <g fill="#1c6f4f">
+          {[330, 360, 392].map((y, r) =>
+            Array.from({ length: 9 }, (_, c) => (
+              <circle key={`${r}-${c}`} cx={90 + c * 80} cy={y} r={5} />
+            )),
+          )}
+        </g>
+      )}
+
+      {/* 夕暮れの灯り (第四話) */}
+      {p.motif === 'lanterns' && (
+        <g>
+          {[
+            [250, 320],
+            [360, 338],
+            [470, 322],
+            [560, 344],
+          ].map(([x, y], i) => (
+            <g key={i}>
+              <circle cx={x} cy={y} r="18" fill="#ffd98c" opacity="0.45" />
+              <circle cx={x} cy={y} r="6" fill="#ffe6ac" />
+            </g>
+          ))}
+        </g>
+      )}
+
+      {/* 谷を上る一本道 (エピローグ) */}
+      {p.motif === 'path' && (
+        <path
+          d="M380 460 C380 410 470 392 470 350 C470 314 360 306 360 276 C360 252 430 244 430 220"
+          fill="none"
+          stroke="#fffdf7"
+          strokeOpacity="0.78"
+          strokeWidth="14"
+          strokeLinecap="round"
+        />
+      )}
+    </svg>
+  )
+}

--- a/src/components/StoryReader.test.tsx
+++ b/src/components/StoryReader.test.tsx
@@ -7,11 +7,13 @@ const pages: StoryPage[] = [
   {
     kicker: 'プロローグ',
     title: '冬の、秘境へ',
+    art: 'winter',
     paragraphs: ['ある年の冬。', '「二度芋を、つくってみませんか」'],
   },
   {
     kicker: '第一話',
     title: '一枚の貼り紙',
+    art: 'notice',
     paragraphs: ['伝承館の片隅に、一枚の貼り紙。'],
   },
   {
@@ -138,6 +140,34 @@ describe('StoryReader', () => {
       screen.getByRole('heading', { name: '畑は、続いていく' }),
     ).toBeInTheDocument()
     expect(window.location.hash).toBe('#p3')
+  })
+
+  it('art を持つページではページ送りで挿絵 (SVG) が切り替わる', async () => {
+    const user = userEvent.setup()
+    render(<StoryReader pages={pages} />)
+
+    // 1 ページ目はプロローグの挿絵
+    expect(
+      screen.getByRole('img', { name: 'プロローグ「冬の、秘境へ」の情景' }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '次の話' }))
+
+    // 2 ページ目では第一話の挿絵に切り替わる
+    expect(
+      screen.getByRole('img', { name: '第一話「一枚の貼り紙」の情景' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('img', { name: 'プロローグ「冬の、秘境へ」の情景' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('art を持たないページでは挿絵を描画しない', () => {
+    const noArt: StoryPage[] = [
+      { kicker: 'テスト', title: '挿絵なし', paragraphs: ['本文'] },
+    ]
+    render(<StoryReader pages={noArt} />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
   it('空文字列の段落は情景の「間」としてスペーサー描画される', () => {

--- a/src/components/StoryReader.tsx
+++ b/src/components/StoryReader.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import StoryArt, { type StoryScene } from './StoryArt'
 
 /**
  * StoryReader — 「活動の始まり物語」をライトノベル風に読ませるリーダー島。
@@ -18,6 +19,8 @@ export interface StoryPage {
   title: string
   /** 本文段落。「」で始まる行はセリフとして字下げしない。 */
   paragraphs: string[]
+  /** 章の情景に合わせたベクター挿絵 (StoryArt のシーン)。ページ送りで切り替わる。 */
+  art?: StoryScene
 }
 
 /** 各ページ末尾に添える注記 (実話ベース + AI 編集の明示)。 */
@@ -112,53 +115,63 @@ export default function StoryReader({ pages }: { pages: StoryPage[] }) {
       {/* 本文カード */}
       <article
         aria-live="polite"
-        className="overflow-hidden rounded-3xl border border-primary/10 border-t-4 border-t-sunlight bg-surface px-6 py-10 shadow-sm md:px-12 md:py-14"
+        className="overflow-hidden rounded-3xl border border-primary/10 border-t-4 border-t-sunlight bg-surface shadow-sm"
       >
-        <h2 className="mb-8 font-serif text-2xl font-medium leading-snug text-primary md:text-3xl">
-          {page.title}
-        </h2>
-        <div className="space-y-5 font-serif text-[1.05rem] leading-loose text-body md:text-lg">
-          {page.paragraphs.map((text, i) => {
-            const isDialogue = text.startsWith('「')
-            // 空文字は行間 (情景の「間」) として小さなスペーサーにする。
-            if (text === '') {
-              return <div key={i} className="h-3" aria-hidden="true" />
-            }
-            return (
-              <p key={i} className={isDialogue ? '' : 'indent-4'}>
-                {text}
-              </p>
-            )
-          })}
-        </div>
-
-        {/* 最終ページの CTA: 「知る → 参加する」へ送り出す */}
-        {isLast && (
-          <div className="mt-10 rounded-2xl bg-sunlight-soft/60 px-6 py-7 text-center">
-            <p className="font-serif text-lg text-primary-deep">
-              物語の続きは、ここにあります。
-            </p>
-            <div className="mt-5 flex flex-wrap justify-center gap-3">
-              <a
-                className="inline-flex items-center justify-center gap-2 rounded-full bg-accent-strong px-8 py-3 font-medium text-white shadow-sm transition-all hover:-translate-y-0.5 hover:opacity-90 hover:shadow-lg"
-                href={JOIN_URL}
-              >
-                あなたも耕してみる
-              </a>
-              <a
-                className="inline-flex items-center justify-center gap-2 rounded-full border border-accent-strong bg-surface px-8 py-3 font-medium text-accent-strong transition-all hover:-translate-y-0.5 hover:bg-accent-strong hover:text-white hover:shadow-lg"
-                href="/news"
-              >
-                その後の近況を見る
-              </a>
-            </div>
-          </div>
+        {/* 章の情景挿絵: ページを送るたびに「同じ谷の違う表情」が現れる */}
+        {page.art && (
+          <StoryArt
+            scene={page.art}
+            title={`${page.kicker}「${page.title}」の情景`}
+            className="aspect-[16/7] w-full"
+          />
         )}
+        <div className="px-6 py-10 md:px-12 md:py-14">
+          <h2 className="mb-8 font-serif text-2xl font-medium leading-snug text-primary md:text-3xl">
+            {page.title}
+          </h2>
+          <div className="space-y-5 font-serif text-[1.05rem] leading-loose text-body md:text-lg">
+            {page.paragraphs.map((text, i) => {
+              const isDialogue = text.startsWith('「')
+              // 空文字は行間 (情景の「間」) として小さなスペーサーにする。
+              if (text === '') {
+                return <div key={i} className="h-3" aria-hidden="true" />
+              }
+              return (
+                <p key={i} className={isDialogue ? '' : 'indent-4'}>
+                  {text}
+                </p>
+              )
+            })}
+          </div>
 
-        {/* 実話ベース + AI 編集の注記 (各ページ末尾) */}
-        <p className="mt-10 border-t border-primary/10 pt-5 text-xs leading-relaxed text-body/55">
-          {STORY_NOTE}
-        </p>
+          {/* 最終ページの CTA: 「知る → 参加する」へ送り出す */}
+          {isLast && (
+            <div className="mt-10 rounded-2xl bg-sunlight-soft/60 px-6 py-7 text-center">
+              <p className="font-serif text-lg text-primary-deep">
+                物語の続きは、ここにあります。
+              </p>
+              <div className="mt-5 flex flex-wrap justify-center gap-3">
+                <a
+                  className="inline-flex items-center justify-center gap-2 rounded-full bg-accent-strong px-8 py-3 font-medium text-white shadow-sm transition-all hover:-translate-y-0.5 hover:opacity-90 hover:shadow-lg"
+                  href={JOIN_URL}
+                >
+                  あなたも耕してみる
+                </a>
+                <a
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-accent-strong bg-surface px-8 py-3 font-medium text-accent-strong transition-all hover:-translate-y-0.5 hover:bg-accent-strong hover:text-white hover:shadow-lg"
+                  href="/news"
+                >
+                  その後の近況を見る
+                </a>
+              </div>
+            </div>
+          )}
+
+          {/* 実話ベース + AI 編集の注記 (各ページ末尾) */}
+          <p className="mt-10 border-t border-primary/10 pt-5 text-xs leading-relaxed text-body/55">
+            {STORY_NOTE}
+          </p>
+        </div>
       </article>
 
       {/* ページ送りコントロール */}

--- a/src/pages/story.astro
+++ b/src/pages/story.astro
@@ -1,9 +1,9 @@
 ---
 import BaseLayout from '~/layouts/BaseLayout.astro'
-import BlurImage from '~/components/BlurImage.astro'
 import Container from '~/components/Container.astro'
+import Button from '~/components/Button.astro'
 import StoryReader, { type StoryPage } from '~/components/StoryReader.tsx'
-import mountsImage from '~/assets/mounts.jpg'
+import StoryArt from '~/components/StoryArt.tsx'
 
 /*
  * 「活動の始まり物語」。
@@ -18,6 +18,7 @@ const pages: StoryPage[] = [
   {
     kicker: 'プロローグ',
     title: '冬の、秘境へ',
+    art: 'winter',
     paragraphs: [
       'ある年の冬。私は何人かの友人とともに、南信州の秘境へ向かっていた。',
       '長野県の南の端、赤石山脈――南アルプスの西の麓に、遠山郷と呼ばれる谷あいの里がある。新幹線も高速道路の出口も遠く、くねくねと山道を登った先にようやくたどり着く、文字どおりの「秘境」だ。',
@@ -31,6 +32,7 @@ const pages: StoryPage[] = [
   {
     kicker: '第一話',
     title: '一枚の貼り紙',
+    art: 'notice',
     paragraphs: [
       '遠山郷の中心、上村の上町に、「祭り伝承館」という小さな施設がある。',
       'この地に古くから伝わる霜月祭り――湯立神楽の湯気の向こうに神々の面が浮かぶ、国指定重要無形民俗文化財の祭り――その映像や、実際に使われる面の数々が展示されている。外には昔の暮らしぶりがしのばれる古い民家も公開されていて、囲炉裏の匂いがそのまま染みついていそうな場所だった。',
@@ -48,6 +50,7 @@ const pages: StoryPage[] = [
   {
     kicker: '第二話',
     title: '二度芋は、二度芋だ',
+    art: 'seed',
     paragraphs: [
       '気になった私は、施設の管理人さんらしき人をつかまえて、思いきって尋ねてみた。',
       'その人いわく、二度芋というのは小さな芋で、白いのと、赤っぽいのとがあるという。そして、一年に二度も収穫できるから「二度芋」なのだ、と。なるほど、二期作ができるということか。',
@@ -69,6 +72,7 @@ const pages: StoryPage[] = [
   {
     kicker: '第三話',
     title: 'はじめての農作業',
+    art: 'field',
     paragraphs: [
       '翌春。私は約束どおり、下栗の里に立っていた。',
       'とくに初めての年は、作付けから収穫まで、地域の方々がそれはもう丁寧に、手取り足取り教えてくれた。種芋の置き方、土の寄せ方、草の取り方。ひとつひとつに、長い年月で磨かれた理屈があった。',
@@ -82,6 +86,7 @@ const pages: StoryPage[] = [
   {
     kicker: '第四話',
     title: '通うようになった理由',
+    art: 'gather',
     paragraphs: [
       '年に何度か、慰労会が開かれた。',
       '指導してくださる地域の方々や、先輩ボランティアたちと、とりとめのない話をしながら飲み食いする。畑では聞けない谷の昔話や、誰それの噂話。そういう時間が、作業そのものと同じくらい楽しかった。',
@@ -96,6 +101,7 @@ const pages: StoryPage[] = [
   {
     kicker: 'エピローグ',
     title: '活動は、続いていく',
+    art: 'dawn',
     paragraphs: [
       'そして、物語はここから少しずつ枝を広げていく。',
       '私たちの「やってみたい」と、地域の指導者たちの親切――あるいは、ちょっとした思惑?――が重なって、私たちは大豆の畑をはじめ、やがて茶畑にまで手を伸ばすことになる。手摘みのお茶づくりなんて、最初は誰も本気で考えていなかったはずなのに。',
@@ -112,37 +118,51 @@ const pages: StoryPage[] = [
 ---
 
 <BaseLayout title="遠山郷との始まり">
-  <section
-    class="relative overflow-hidden bg-gradient-to-b from-sky-soft via-base to-base px-4 pt-14 pb-10 text-center sm:pt-20"
-  >
-    <span
-      class="mx-auto mb-4 flex w-fit items-center gap-2 rounded-full bg-sunlight-soft px-4 py-1 font-serif text-sm tracking-wide text-primary-deep
-             before:content-['▲'] before:text-xs before:text-accent-strong"
+  <!-- ヒーロー: トップページ (index.astro) と同じレスポンシブ構成を踏襲する。
+       ただしライトノベルらしく、実写ではなく手描き風のベクターアート (StoryArt)
+       をキービジュアルに用いる。
+       - スマホ (~md): アートを「切れない」バナーとして上に置き、文は下のクリーム地へ。
+       - md 以上: アートを全面背景にし、ダークグリーンのスクリム上に白文字で重ねる。 -->
+  <section class="relative isolate overflow-hidden">
+    <div
+      class="relative aspect-[16/9] w-full overflow-hidden md:absolute md:inset-0 md:-z-10 md:aspect-auto md:h-full"
     >
-      AIライトノベル
-    </span>
-    <h1
-      class="font-serif font-medium text-primary text-3xl leading-snug md:text-4xl"
-    >
-      遠山郷との始まり
-    </h1>
-    <p class="mx-auto mt-4 max-w-xl leading-loose text-body">
-      一枚の貼り紙から始まった、ある秘境通いの記録。<br
-        class="hidden sm:inline"
-      />私たちがどうやって遠山郷とつながり、畑を続けてきたのか――その物語をお届けします。
-    </p>
-    <div class="mx-auto mt-8 w-full max-w-3xl">
-      <BlurImage
-        src={mountsImage}
-        alt="遠山郷の山並みと谷あいの里"
-        loading="eager"
-        fetchpriority="high"
-        fade={false}
-        sizes="(min-width: 768px) 768px, 100vw"
-        class="aspect-video w-full overflow-hidden rounded-3xl shadow-lg ring-1 ring-primary/10"
-        imgClass="h-full w-full object-cover"
+      <StoryArt
+        scene="hero"
+        title="陽光のさす谷あいの段々畑を見上げる、ひとりの人影"
+        className="absolute inset-0 h-full w-full"
       />
+      <!-- スクリム: md 以上でのみ全面に重ね、下部の白文字の可読性 (WCAG AA) を確保する。 -->
+      <div
+        aria-hidden="true"
+        class="absolute inset-0 md:bg-gradient-to-t md:from-primary-deep/92 md:via-primary-deep/42 md:to-transparent"
+      >
+      </div>
     </div>
+    <Container
+      size="wide"
+      class="flex flex-col items-center gap-4 px-4 py-6 text-center md:min-h-[clamp(22rem,60svh,34rem)] md:justify-end md:gap-5 md:py-0 md:pb-12 md:pt-24"
+    >
+      <span
+        class="flex w-fit items-center gap-2 rounded-full bg-primary-deep px-4 py-1 font-serif text-sm tracking-wide text-white ring-1 ring-white/25 [text-shadow:0_1px_3px_rgba(15,46,33,0.6)]"
+      >
+        AIライトノベル
+      </span>
+      <h1
+        class="font-serif text-3xl font-medium leading-snug text-primary md:text-5xl md:text-white md:[text-shadow:0_2px_8px_rgba(15,46,33,0.55)]"
+      >
+        遠山郷との始まり
+      </h1>
+      <p
+        class="mx-auto max-w-xl text-justify leading-relaxed text-body md:leading-loose md:text-white md:[text-shadow:0_1px_4px_rgba(15,46,33,0.75)]"
+      >
+        一枚の貼り紙から始まった、ある秘境通いの記録。ひとりの若者がその谷とどう出会い、なぜ何年もかよい続けることになったのか――。まだ何も知らなかった頃から、物語ははじまる。
+      </p>
+      <div class="mt-2 flex flex-wrap justify-center gap-3">
+        <Button href="#p1">物語を読む</Button>
+        <Button href="/join" variant="outline">活動に参加する</Button>
+      </div>
+    </Container>
   </section>
 
   <Container class="py-12 md:py-16">


### PR DESCRIPTION
- トップページのヒーロー構成 (フルブリード背景 + スクリム) を踏襲し、
  実写写真ではなく手描き風のベクターアート (StoryArt) をキービジュアルに採用
- StoryArt: 「空→遠/中/近の山並み→段々畑」の共通構図を保ちつつ、配色 (時間帯・
  季節) と前景モチーフだけを差し替え、ページ送りごとに「同じ谷の違う表情」を表示
- StoryReader: 各章 (art シーン) の挿絵をカード上部に描画し、ページ送りで切り替え
- ヒーロー文を第三者目線に改稿し、「ある秘境通いの記録」の直後に地名を出して
  伏線を明かしてしまわないよう表現を調整 (遠山郷/私たち を本文から外す)
- バッジを淡色ピル+▲ から濃緑ベタピルへ (デザイン規則のラベルピル方針に追従)
- StoryArt / StoryReader の挿絵切替に Vitest テストを追加

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013J9FQWgfqWYCD5y1CvjXMT