### PR TITLE
Adjust hero section layout and image positioning for better composition

### DIFF
--- a/e2e/hero-image-position.spec.ts
+++ b/e2e/hero-image-position.spec.ts
@@ -11,14 +11,14 @@ import { test, expect } from '@playwright/test'
  * カスケードレイヤー規則により、specificity に関わらず Astro 側が勝つ。結果:
  *   1. <img> の h-full が height:auto に負け、高さが制限されず原寸比で描画される
  *      → object-fit:cover のトリミングが起きず object-position が無効化される。
- *   2. md:object-[50%_68%] が data-astro-image-pos="center" に負ける。
+ *   2. md:object-[50%_38%] が data-astro-image-pos="center" に負ける。
  * いずれも ! (important) で勝たせて修正する。computed style と実レイアウトは
  * 実ブラウザでしか正しく解決できないため、ここで回帰を固定する。
  */
 
 const HERO_ALT = '遠山郷の急斜面に広がる畑と山並み'
 
-test('デスクトップでヒーロー画像が高さ制限され object-position 50% 68% が効く', async ({
+test('デスクトップでヒーロー画像が高さ制限され object-position 50% 38% が効く', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 800 })
@@ -27,11 +27,11 @@ test('デスクトップでヒーロー画像が高さ制限され object-positi
   const heroImg = page.locator(`img[alt="${HERO_ALT}"]`)
   await expect(heroImg).toBeVisible()
 
-  // object-position が中央に戻されず 50% 68% で解決されていること
+  // object-position が中央に戻されず 50% 38% で解決されていること
   const objectPosition = await heroImg.evaluate(
     (el) => getComputedStyle(el).objectPosition,
   )
-  expect(objectPosition).toBe('50% 68%')
+  expect(objectPosition).toBe('50% 38%')
 
   // 高さが制限され (h-full)、object-fit:cover のトリミングが効いていること。
   // height:auto に負けると <img> は原寸比 (4028:3120 ≒ 0.77) の高さになり、

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,8 @@ const intensityLabel: Record<Intensity, string> = {
              1. height: <img> の h-full が height:auto に負けると高さが制限されず、画像が原寸比で
                 描画されて object-fit のトリミングが起きない (= object-position が無効化される)。
              2. object-position: md:object-[50%_68%] が data-astro-image-pos="center" に負ける。
-           md 以上は被写体 (山並み) を下げ気味に見せるため object-position を 50% 68% にする。 -->
+           md 以上は被写体 (空〜山並み) を上寄りに見せ、ワイド画面でも空が残り
+           バッジが空に載るよう object-position を 50% 38% にする。 -->
       <BlurImage
         src={heroImage}
         alt="遠山郷の急斜面に広がる畑と山並み"
@@ -61,7 +62,7 @@ const intensityLabel: Record<Intensity, string> = {
         fade={false}
         sizes="100vw"
         class="absolute inset-0 h-full w-full"
-        imgClass="h-full! w-full object-cover object-center md:object-[50%_68%]!"
+        imgClass="h-full! w-full object-cover object-center md:object-[50%_38%]!"
       />
       <!-- スクリム: md 以上でのみ全面に重ね、下部の白文字の可読性 (WCAG AA) を確保する。
            スマホでは写真をそのまま見せる (テキストは下のクリーム地に置くため不要)。 -->
@@ -73,7 +74,7 @@ const intensityLabel: Record<Intensity, string> = {
     </div>
     <Container
       size="wide"
-      class="flex flex-col items-center gap-4 px-4 py-6 text-center md:min-h-[clamp(24rem,68svh,38rem)] md:justify-end md:gap-5 md:py-0 md:pb-12 md:pt-24"
+      class="flex flex-col items-center gap-4 px-4 py-6 text-center md:min-h-[clamp(22rem,58svh,32rem)] md:justify-end md:gap-5 md:py-0 md:pb-12 md:pt-16"
     >
       <span
         class="flex w-fit items-center gap-2 rounded-full bg-primary-deep px-4 py-1 font-serif text-sm tracking-wide text-white ring-1 ring-white/25 [text-shadow:0_1px_3px_rgba(15,46,33,0.6)]"


### PR DESCRIPTION
## Summary
Refined the hero section's visual composition by adjusting the background image positioning and container dimensions to better showcase the sky and ensure the badge element sits properly within it on wider screens.

## Changes
- **Image positioning**: Changed `object-position` from `50% 68%` to `50% 38%` on md+ breakpoints
  - Shifts the focal point upward to emphasize the sky-to-mountains composition
  - Ensures the sky remains visible on wide screens where the badge is positioned
  - Updated the accompanying comment to reflect the new intent

- **Container dimensions**: Adjusted hero section height constraints on md+ breakpoints
  - `min-h-[clamp(24rem,68svh,38rem)]` → `min-h-[clamp(22rem,58svh,32rem)]`
  - `pt-24` → `pt-16`
  - Reduces overall hero height to better balance the composition with the adjusted image positioning

## Implementation Details
These changes work together to create a more cohesive visual hierarchy where the sky occupies a more prominent position in the composition, allowing the badge to sit naturally within the sky area rather than overlapping the mountain landscape.

https://claude.ai/code/session_015F7Jc4tGKrhhA4LJWaWmfB