### PR TITLE
Adjust JourneyCards grid layout for better mobile responsiveness

### DIFF
--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -72,13 +72,13 @@ const tints = {
 }
 ---
 
-<ul class="grid gap-5 sm:grid-cols-3">
+<ul class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
   {
     journeys.map((j) => {
       const t = tints[j.tint as keyof typeof tints]
       return (
         <li
-          class:list={['sm:flex', j.featured && 'sm:col-span-3 lg:col-span-1']}
+          class:list={['sm:flex', j.featured && 'sm:col-span-2 lg:col-span-1']}
         >
           <Card
             as="div"


### PR DESCRIPTION
## Summary
Updated the JourneyCards component grid layout to improve responsiveness on tablet and smaller screens by adjusting column spans across breakpoints.

## Changes
- Changed base grid from `sm:grid-cols-3` to `sm:grid-cols-2` with `lg:grid-cols-3` to provide a 2-column layout on tablets and 3-column on larger screens
- Updated featured card span from `sm:col-span-3` to `sm:col-span-2` to maintain proper proportions when featured cards appear in a 2-column grid on tablets

## Details
This adjustment ensures the journey cards (参加する / 成果品 / 支える) display appropriately across all viewport sizes:
- Mobile: 1 column (unchanged)
- Tablet (sm-lg): 2 columns with featured cards spanning 2 columns
- Desktop (lg+): 3 columns with featured cards spanning 1 column

The change improves the visual hierarchy and readability on medium-sized screens without affecting the desktop experience.

https://claude.ai/code/session_019pCmDEzdMBwTh7Qt2Rksor