### PR TITLE
Add gradient background and border styling to hero section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -74,7 +74,7 @@ const intensityLabel: Record<Intensity, string> = {
     </div>
     <Container
       size="wide"
-      class="flex flex-col items-center gap-4 px-4 py-6 text-center md:min-h-[clamp(22rem,58svh,32rem)] md:justify-end md:gap-5 md:py-0 md:pb-12 md:pt-16"
+      class="flex flex-col items-center gap-4 border-b border-primary/10 bg-gradient-to-b from-sunlight-soft/30 to-base px-4 py-6 text-center md:min-h-[clamp(22rem,58svh,32rem)] md:justify-end md:gap-5 md:border-0 md:bg-none md:py-0 md:pb-12 md:pt-16"
     >
       <span
         class="flex w-fit items-center gap-2 rounded-full bg-primary-deep px-4 py-1 font-serif text-sm tracking-wide text-white ring-1 ring-white/25 [text-shadow:0_1px_3px_rgba(15,46,33,0.6)]"


### PR DESCRIPTION
## Summary
Enhanced the visual design of the hero section on the homepage by adding a gradient background and top border that creates a more polished, layered appearance.

## Changes
- Added a gradient background (`from-sunlight-soft/30 to-base`) to the hero container that creates a subtle depth effect
- Added a top border with primary color at reduced opacity (`border-b border-primary/10`) for visual separation
- Removed these styles on medium screens and above (`md:border-0 md:bg-none`) to maintain the original desktop layout

## Implementation Details
- The gradient uses existing design tokens (`sunlight-soft` and `base` colors) to maintain design consistency
- The border opacity (`/10`) is subtle enough to not distract from content while providing visual structure
- Responsive behavior ensures the enhancement only applies to mobile/tablet views, preserving the desktop design intent

https://claude.ai/code/session_01NKr4Bwrv9kc8sEb9CSq3Ep