### PR TITLE
feat(Button): 別ページ遷移ボタンの末尾に矢印を追加

### DIFF
--- a/src/components/ArrowIcon.astro
+++ b/src/components/ArrowIcon.astro
@@ -1,0 +1,47 @@
+---
+/**
+ * ArrowIcon — リンク末尾に添える矢印アイコン (SVG)。
+ *
+ * ボタン (Button.astro) とカード内などのテキストリンクで共用し、サイト全体で
+ * 矢印の形を統一する。currentColor で文字色に同調し、サイズ・ホバー演出は
+ * 呼び出し側が `class` で渡す (例: 'h-[1.2em] w-[1.2em] group-hover:translate-x-0.5')。
+ *
+ * - external=false: 右矢印 (サイト内ページへ前進)。矢じり (傘) を広く取り視認性を確保
+ * - external=true:  四角の枠から斜め右上に飛び出す矢印 (標準の「別タブで開く」記号)
+ *
+ * 内部・外部とも viewBox 24・stroke-width 2 で線幅の見えを揃える。装飾なので aria-hidden。
+ * 左向き (前の項目へ) が要る場合は呼び出し側で `-scale-x-100` を付けて反転する。
+ */
+interface Props {
+  external?: boolean
+  class?: string
+}
+
+const { external = false, class: className = '' } = Astro.props
+---
+
+<svg
+  aria-hidden="true"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class:list={['shrink-0', className]}
+>
+  {
+    external ? (
+      <>
+        <path d="M18 13v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />
+        <path d="M14 5h5v5" />
+        <path d="M19 5l-8 8" />
+      </>
+    ) : (
+      <>
+        <path d="M5 12h13" />
+        <path d="M11 6l6 6-6 6" />
+      </>
+    )
+  }
+</svg>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -11,7 +11,7 @@
  *
  * アイコンは ArrowIcon.astro (SVG) を共用し、サイト全体で矢印の形を統一する。
  */
-import { resolveButtonArrow } from '~/components/buttonArrow'
+import { resolveButtonArrow, isExternalHref } from '~/components/buttonArrow'
 import ArrowIcon from '~/components/ArrowIcon.astro'
 
 interface Props {
@@ -23,13 +23,13 @@ interface Props {
 }
 
 const { href, variant = 'accent', arrow, class: className = '' } = Astro.props
-const external = href.startsWith('http')
+const external = isExternalHref(href)
 
 // 末尾矢印の種別 (internal / external / null) を href から判定する
 const buttonArrow = resolveButtonArrow(href, arrow)
 
 const base =
-  'group inline-flex items-center justify-center gap-2 px-8 py-3 rounded-full font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
+  'group inline-flex items-center justify-center gap-2 px-8 py-3 rounded-full font-medium transition-all motion-safe:hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
 const variants = {
   // 白文字を載せる CTA は WCAG AA を満たす accent-strong を使用
   accent: 'bg-accent-strong text-white hover:opacity-90',
@@ -46,14 +46,14 @@ const variants = {
   <slot />
   {
     buttonArrow === 'internal' && (
-      <ArrowIcon class="h-[1.2em] w-[1.2em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
+      <ArrowIcon class="h-[1.2em] w-[1.2em] transition-transform motion-safe:group-hover:translate-x-0.5" />
     )
   }
   {
     buttonArrow === 'external' && (
       <ArrowIcon
         external
-        class="h-[1.05em] w-[1.05em] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transition-none"
+        class="h-[1.05em] w-[1.05em] transition-transform motion-safe:group-hover:-translate-y-0.5 motion-safe:group-hover:translate-x-0.5"
       />
     )
   }

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,18 +2,31 @@
 /**
  * Button — CTA ボタン (README 2.4)。
  * 既定は accent(テラコッタ) 背景 + 白文字 (WCAG AA)、丸み rounded-full。
+ *
+ * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう末尾に矢印を付ける。
+ * - 内部ページ (/...): → (前進＝サイト内で次のページへ)。ホバーで右へ少し動く
+ * - 外部リンク (http...): ↗ (別タブ・外部サイトへ。SiteHeader の外部リンク表記と統一)
+ * - 同一ページ内アンカー (#...): 矢印なし (ページ遷移ではなくスクロールのため)
+ * `arrow` を明示すると自動判定を上書きできる (true=→ を強制 / false=矢印なし)。
  */
+import { resolveButtonArrow } from '~/components/buttonArrow'
+
 interface Props {
   href: string
   variant?: 'accent' | 'outline'
+  /** 矢印の表示を上書き (既定は href から自動判定) */
+  arrow?: boolean
   class?: string
 }
 
-const { href, variant = 'accent', class: className = '' } = Astro.props
+const { href, variant = 'accent', arrow, class: className = '' } = Astro.props
 const external = href.startsWith('http')
 
+// 末尾矢印 (内部 → / 外部 ↗ / アンカーなし) を href から判定する
+const buttonArrow = resolveButtonArrow(href, arrow)
+
 const base =
-  'inline-flex items-center justify-center gap-2 px-8 py-3 rounded-full font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
+  'group inline-flex items-center justify-center gap-2 px-8 py-3 rounded-full font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent'
 const variants = {
   // 白文字を載せる CTA は WCAG AA を満たす accent-strong を使用
   accent: 'bg-accent-strong text-white hover:opacity-90',
@@ -28,4 +41,19 @@ const variants = {
   {...external ? { target: '_blank', rel: 'noopener noreferrer' } : {}}
 >
   <slot />
+  {
+    buttonArrow && (
+      <span
+        aria-hidden="true"
+        class:list={[
+          'transition-transform',
+          buttonArrow.external
+            ? 'group-hover:-translate-y-0.5 group-hover:translate-x-0.5'
+            : 'group-hover:translate-x-0.5',
+        ]}
+      >
+        {buttonArrow.glyph}
+      </span>
+    )
+  }
 </a>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -4,15 +4,15 @@
  * 既定は accent(テラコッタ) 背景 + 白文字 (WCAG AA)、丸み rounded-full。
  *
  * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう末尾に矢印アイコンを付ける。
- * - 内部ページ (/...): 短い右矢印 (前進＝サイト内で次のページへ)。ホバーで右へ少し動く
+ * - 内部ページ (/...): 右矢印 (前進＝サイト内で次のページへ)。ホバーで右へ少し動く
  * - 外部リンク (http...): 四角から斜めに飛び出す矢印 (別タブ・外部サイトへ)
  * - 同一ページ内アンカー (#...): 矢印なし (ページ遷移ではなくスクロールのため)
  * `arrow` を明示すると自動判定を上書きできる (true=矢印あり / false=矢印なし)。
  *
- * アイコンは SVG (currentColor で文字色に同調 / em でフォントサイズに追従)。
- * 内部・外部とも viewBox 24・stroke-width 2 で線幅の見えを揃える。aria-hidden。
+ * アイコンは ArrowIcon.astro (SVG) を共用し、サイト全体で矢印の形を統一する。
  */
 import { resolveButtonArrow } from '~/components/buttonArrow'
+import ArrowIcon from '~/components/ArrowIcon.astro'
 
 interface Props {
   href: string
@@ -36,9 +36,6 @@ const variants = {
   outline:
     'border border-accent-strong text-accent-strong bg-surface hover:bg-accent-strong hover:text-white',
 }
-
-// 矢印アイコンの共通属性 (線端を丸めて柔らかく / 線幅の見えを揃える)。サイズは個別指定
-const iconBase = 'shrink-0 transition-transform motion-reduce:transition-none'
 ---
 
 <a
@@ -49,46 +46,15 @@ const iconBase = 'shrink-0 transition-transform motion-reduce:transition-none'
   <slot />
   {
     buttonArrow === 'internal' && (
-      // 右矢印 (傘=矢じりを広く開き視認性を上げる)。ホバーで右へ前進
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class:list={[
-          iconBase,
-          'h-[1.2em] w-[1.2em] group-hover:translate-x-0.5',
-        ]}
-      >
-        <path d="M5 12h13" />
-        <path d="M11 6l6 6-6 6" />
-      </svg>
+      <ArrowIcon class="h-[1.2em] w-[1.2em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
     )
   }
   {
     buttonArrow === 'external' && (
-      // 四角の枠から斜め右上に飛び出す矢印 (標準の「別タブで開く」記号)。
-      // ホバーで枠から少し飛び出すように右上へ動く
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class:list={[
-          iconBase,
-          'h-[1.05em] w-[1.05em] group-hover:-translate-y-0.5 group-hover:translate-x-0.5',
-        ]}
-      >
-        <path d="M18 13v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />
-        <path d="M14 5h5v5" />
-        <path d="M19 5l-8 8" />
-      </svg>
+      <ArrowIcon
+        external
+        class="h-[1.05em] w-[1.05em] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transition-none"
+      />
     )
   }
 </a>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -3,11 +3,14 @@
  * Button — CTA ボタン (README 2.4)。
  * 既定は accent(テラコッタ) 背景 + 白文字 (WCAG AA)、丸み rounded-full。
  *
- * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう末尾に矢印を付ける。
- * - 内部ページ (/...): → (前進＝サイト内で次のページへ)。ホバーで右へ少し動く
- * - 外部リンク (http...): ↗ (別タブ・外部サイトへ。SiteHeader の外部リンク表記と統一)
+ * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう末尾に矢印アイコンを付ける。
+ * - 内部ページ (/...): 短い右矢印 (前進＝サイト内で次のページへ)。ホバーで右へ少し動く
+ * - 外部リンク (http...): 四角から斜めに飛び出す矢印 (別タブ・外部サイトへ)
  * - 同一ページ内アンカー (#...): 矢印なし (ページ遷移ではなくスクロールのため)
- * `arrow` を明示すると自動判定を上書きできる (true=→ を強制 / false=矢印なし)。
+ * `arrow` を明示すると自動判定を上書きできる (true=矢印あり / false=矢印なし)。
+ *
+ * アイコンは SVG (currentColor で文字色に同調 / em でフォントサイズに追従)。
+ * 内部・外部とも viewBox 24・stroke-width 2 で線幅の見えを揃える。aria-hidden。
  */
 import { resolveButtonArrow } from '~/components/buttonArrow'
 
@@ -22,7 +25,7 @@ interface Props {
 const { href, variant = 'accent', arrow, class: className = '' } = Astro.props
 const external = href.startsWith('http')
 
-// 末尾矢印 (内部 → / 外部 ↗ / アンカーなし) を href から判定する
+// 末尾矢印の種別 (internal / external / null) を href から判定する
 const buttonArrow = resolveButtonArrow(href, arrow)
 
 const base =
@@ -33,6 +36,10 @@ const variants = {
   outline:
     'border border-accent-strong text-accent-strong bg-surface hover:bg-accent-strong hover:text-white',
 }
+
+// 矢印アイコンの共通属性 (em 追従 / 線端を丸めて柔らかく / 線幅の見えを揃える)
+const iconBase =
+  'h-[1.05em] w-[1.05em] shrink-0 transition-transform motion-reduce:transition-none'
 ---
 
 <a
@@ -42,18 +49,44 @@ const variants = {
 >
   <slot />
   {
-    buttonArrow && (
-      <span
+    buttonArrow === 'internal' && (
+      // 短い右矢印 (軸を詰めた小ぶりな矢印)。ホバーで右へ前進
+      <svg
         aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class:list={[iconBase, 'group-hover:translate-x-0.5']}
+      >
+        <path d="M8 12h8" />
+        <path d="M12 8l4 4-4 4" />
+      </svg>
+    )
+  }
+  {
+    buttonArrow === 'external' && (
+      // 四角の枠から斜め右上に飛び出す矢印 (標準の「別タブで開く」記号)。
+      // ホバーで枠から少し飛び出すように右上へ動く
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
         class:list={[
-          'transition-transform',
-          buttonArrow.external
-            ? 'group-hover:-translate-y-0.5 group-hover:translate-x-0.5'
-            : 'group-hover:translate-x-0.5',
+          iconBase,
+          'group-hover:-translate-y-0.5 group-hover:translate-x-0.5',
         ]}
       >
-        {buttonArrow.glyph}
-      </span>
+        <path d="M18 13v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />
+        <path d="M14 5h5v5" />
+        <path d="M19 5l-8 8" />
+      </svg>
     )
   }
 </a>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -37,9 +37,8 @@ const variants = {
     'border border-accent-strong text-accent-strong bg-surface hover:bg-accent-strong hover:text-white',
 }
 
-// 矢印アイコンの共通属性 (em 追従 / 線端を丸めて柔らかく / 線幅の見えを揃える)
-const iconBase =
-  'h-[1.05em] w-[1.05em] shrink-0 transition-transform motion-reduce:transition-none'
+// 矢印アイコンの共通属性 (線端を丸めて柔らかく / 線幅の見えを揃える)。サイズは個別指定
+const iconBase = 'shrink-0 transition-transform motion-reduce:transition-none'
 ---
 
 <a
@@ -50,7 +49,7 @@ const iconBase =
   <slot />
   {
     buttonArrow === 'internal' && (
-      // 短い右矢印 (軸を詰めた小ぶりな矢印)。ホバーで右へ前進
+      // 右矢印 (傘=矢じりを広く開き視認性を上げる)。ホバーで右へ前進
       <svg
         aria-hidden="true"
         viewBox="0 0 24 24"
@@ -59,10 +58,13 @@ const iconBase =
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"
-        class:list={[iconBase, 'group-hover:translate-x-0.5']}
+        class:list={[
+          iconBase,
+          'h-[1.2em] w-[1.2em] group-hover:translate-x-0.5',
+        ]}
       >
-        <path d="M8 12h8" />
-        <path d="M12 8l4 4-4 4" />
+        <path d="M5 12h13" />
+        <path d="M11 6l6 6-6 6" />
       </svg>
     )
   }
@@ -80,7 +82,7 @@ const iconBase =
         stroke-linejoin="round"
         class:list={[
           iconBase,
-          'group-hover:-translate-y-0.5 group-hover:translate-x-0.5',
+          'h-[1.05em] w-[1.05em] group-hover:-translate-y-0.5 group-hover:translate-x-0.5',
         ]}
       >
         <path d="M18 13v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />

--- a/src/components/ComingSoon.astro
+++ b/src/components/ComingSoon.astro
@@ -38,7 +38,7 @@ const { title, description } = Astro.props
       公開までもうしばらくお待ちください。最新の活動の様子はトップページや募集ページでご覧いただけます。
     </p>
     <div class="mt-8 flex flex-wrap justify-center gap-3">
-      <Button href="/" variant="outline">トップへ戻る</Button>
+      <Button href="/" variant="outline" arrow={false}>トップへ戻る</Button>
       <Button href="https://activo.jp/s/a/119414">ボランティア募集を見る</Button
       >
     </div>

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -7,6 +7,7 @@
  * カード全体をリンクにして、どこをタップしても次の一歩へ進めるようにする。
  */
 import Card from '~/components/Card.astro'
+import ArrowIcon from '~/components/ArrowIcon.astro'
 
 interface Journey {
   href: string
@@ -127,7 +128,10 @@ const tints = {
                 ]}
               >
                 {j.cta}
-                <span aria-hidden="true">→</span>
+                <ArrowIcon
+                  external={j.external}
+                  class="h-[1.15em] w-[1.15em]"
+                />
               </span>
             </a>
           </Card>

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -123,7 +123,7 @@ const tints = {
               <p class="grow text-sm leading-relaxed text-body">{j.desc}</p>
               <span
                 class:list={[
-                  'mt-1 inline-flex items-center gap-1.5 text-sm font-medium transition-transform group-hover:translate-x-0.5',
+                  'mt-1 inline-flex items-center gap-1.5 text-sm font-medium transition-transform motion-safe:group-hover:translate-x-0.5',
                   t.cta,
                 ]}
               >

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -59,7 +59,7 @@ const thumbnail = post.data.images[0]
       >
         続きを読む
         <ArrowIcon
-          class="h-[1.1em] w-[1.1em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none"
+          class="h-[1.1em] w-[1.1em] transition-transform motion-safe:group-hover:translate-x-0.5"
         />
       </span>
     </div>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -8,6 +8,7 @@
 import type { CollectionEntry } from 'astro:content'
 import BlurImage from '~/components/BlurImage.astro'
 import Card from '~/components/Card.astro'
+import ArrowIcon from '~/components/ArrowIcon.astro'
 import { postExcerpt } from '~/components/postExcerpt'
 import { formatPostDate } from '~/components/postDate'
 
@@ -24,7 +25,7 @@ const thumbnail = post.data.images[0]
 <Card as="article" hover class:list={['h-full', className]}>
   <a
     href={`/news/${post.id}`}
-    class="flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-strong focus-visible:ring-offset-2"
+    class="group flex h-full flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-strong focus-visible:ring-offset-2"
   >
     {
       thumbnail && (
@@ -54,9 +55,12 @@ const thumbnail = post.data.images[0]
         )
       }
       <span
-        class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-accent-strong after:content-['→']"
+        class="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent-strong"
       >
         続きを読む
+        <ArrowIcon
+          class="h-[1.1em] w-[1.1em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none"
+        />
       </span>
     </div>
   </a>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -13,6 +13,7 @@
  */
 import Container from '~/components/Container.astro'
 import SiteLogo from '~/components/SiteLogo.astro'
+import ArrowIcon from '~/components/ArrowIcon.astro'
 
 interface Props {
   currentPath?: string
@@ -141,12 +142,10 @@ const ctaVariants = {
                     >
                       {i.title}
                       {i.external && (
-                        <span
-                          aria-hidden="true"
-                          class="text-xs text-primary/50"
-                        >
-                          ↗
-                        </span>
+                        <ArrowIcon
+                          external
+                          class="h-3.5 w-3.5 text-primary/50"
+                        />
                       )}
                     </a>
                   </li>
@@ -241,12 +240,10 @@ const ctaVariants = {
                       >
                         {i.title}
                         {i.external && (
-                          <span
-                            aria-hidden="true"
-                            class="text-xs text-primary/50"
-                          >
-                            ↗
-                          </span>
+                          <ArrowIcon
+                            external
+                            class="h-3.5 w-3.5 text-primary/50"
+                          />
                         )}
                       </a>
                     </li>

--- a/src/components/buttonArrow.test.ts
+++ b/src/components/buttonArrow.test.ts
@@ -1,10 +1,27 @@
 import { describe, it, expect } from 'vitest'
-import { resolveButtonArrow } from './buttonArrow'
+import { resolveButtonArrow, isExternalHref } from './buttonArrow'
+
+describe('isExternalHref', () => {
+  it('http(s):// で始まる URL のみ外部とみなす', () => {
+    expect(isExternalHref('https://shop.tohyamago.org')).toBe(true)
+    expect(isExternalHref('http://example.com')).toBe(true)
+  })
+
+  it('プロトコルなしの相対パスは外部とみなさない', () => {
+    expect(isExternalHref('/join')).toBe(false)
+    expect(isExternalHref('#p1')).toBe(false)
+    // 'http' で始まるが URL ではない相対パス (誤検知しないこと)
+    expect(isExternalHref('http-status')).toBe(false)
+    expect(isExternalHref('/httpie')).toBe(false)
+  })
+})
 
 describe('resolveButtonArrow', () => {
   it('内部ページへのリンクは内部矢印 (前進) を出す', () => {
     expect(resolveButtonArrow('/join')).toBe('internal')
     expect(resolveButtonArrow('/news/archive')).toBe('internal')
+    // 'http' で始まる相対パスは内部扱い
+    expect(resolveButtonArrow('/http-status')).toBe('internal')
   })
 
   it('外部リンク (http/https) は外部矢印 (別タブ) を出す', () => {

--- a/src/components/buttonArrow.test.ts
+++ b/src/components/buttonArrow.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { resolveButtonArrow } from './buttonArrow'
+
+describe('resolveButtonArrow', () => {
+  it('内部ページへのリンクは前進を示す → を出す', () => {
+    expect(resolveButtonArrow('/join')).toEqual({ external: false, glyph: '→' })
+    expect(resolveButtonArrow('/news/archive')).toEqual({
+      external: false,
+      glyph: '→',
+    })
+  })
+
+  it('外部リンク (http/https) は別タブを示す ↗ を出す', () => {
+    expect(resolveButtonArrow('https://shop.tohyamago.org')).toEqual({
+      external: true,
+      glyph: '↗',
+    })
+    expect(resolveButtonArrow('http://example.com')).toEqual({
+      external: true,
+      glyph: '↗',
+    })
+  })
+
+  it('同一ページ内アンカー (#) はページ遷移ではないので矢印を出さない', () => {
+    expect(resolveButtonArrow('#p1')).toBeNull()
+  })
+
+  it('override=false で矢印を強制的に消せる (「戻る」など前進にそぐわない場合)', () => {
+    expect(resolveButtonArrow('/', false)).toBeNull()
+    expect(resolveButtonArrow('https://example.com', false)).toBeNull()
+  })
+
+  it('override=true でアンカーにも矢印を強制できる', () => {
+    expect(resolveButtonArrow('#p1', true)).toEqual({
+      external: false,
+      glyph: '→',
+    })
+  })
+})

--- a/src/components/buttonArrow.test.ts
+++ b/src/components/buttonArrow.test.ts
@@ -2,23 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { resolveButtonArrow } from './buttonArrow'
 
 describe('resolveButtonArrow', () => {
-  it('内部ページへのリンクは前進を示す → を出す', () => {
-    expect(resolveButtonArrow('/join')).toEqual({ external: false, glyph: '→' })
-    expect(resolveButtonArrow('/news/archive')).toEqual({
-      external: false,
-      glyph: '→',
-    })
+  it('内部ページへのリンクは内部矢印 (前進) を出す', () => {
+    expect(resolveButtonArrow('/join')).toBe('internal')
+    expect(resolveButtonArrow('/news/archive')).toBe('internal')
   })
 
-  it('外部リンク (http/https) は別タブを示す ↗ を出す', () => {
-    expect(resolveButtonArrow('https://shop.tohyamago.org')).toEqual({
-      external: true,
-      glyph: '↗',
-    })
-    expect(resolveButtonArrow('http://example.com')).toEqual({
-      external: true,
-      glyph: '↗',
-    })
+  it('外部リンク (http/https) は外部矢印 (別タブ) を出す', () => {
+    expect(resolveButtonArrow('https://shop.tohyamago.org')).toBe('external')
+    expect(resolveButtonArrow('http://example.com')).toBe('external')
   })
 
   it('同一ページ内アンカー (#) はページ遷移ではないので矢印を出さない', () => {
@@ -30,10 +21,8 @@ describe('resolveButtonArrow', () => {
     expect(resolveButtonArrow('https://example.com', false)).toBeNull()
   })
 
-  it('override=true でアンカーにも矢印を強制できる', () => {
-    expect(resolveButtonArrow('#p1', true)).toEqual({
-      external: false,
-      glyph: '→',
-    })
+  it('override=true でアンカーにも矢印を強制できる (種別は href から判定)', () => {
+    expect(resolveButtonArrow('#p1', true)).toBe('internal')
+    expect(resolveButtonArrow('https://example.com', true)).toBe('external')
   })
 })

--- a/src/components/buttonArrow.ts
+++ b/src/components/buttonArrow.ts
@@ -1,0 +1,30 @@
+/**
+ * Button の末尾矢印を href から決める純粋関数。
+ *
+ * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう矢印を付ける。
+ * - 内部ページ (/...): → (サイト内で次のページへ前進)
+ * - 外部リンク (http...): ↗ (別タブ・外部サイトへ。SiteHeader の外部リンク表記と統一)
+ * - 同一ページ内アンカー (#...): なし (ページ遷移ではなくスクロールのため)
+ *
+ * `override` を渡すと自動判定を上書きできる (true=矢印あり / false=矢印なし)。
+ * 「戻る」など前進の意味にそぐわないボタンは呼び出し側で false を指定する。
+ */
+export type ButtonArrow = {
+  /** 外部リンク (別タブ) かどうか */
+  external: boolean
+  /** 表示するグリフ */
+  glyph: '→' | '↗'
+}
+
+export function resolveButtonArrow(
+  href: string,
+  override?: boolean,
+): ButtonArrow | null {
+  const external = href.startsWith('http')
+  const anchor = href.startsWith('#')
+  const showArrow = override ?? !anchor
+  if (!showArrow) return null
+  return external
+    ? { external: true, glyph: '↗' }
+    : { external: false, glyph: '→' }
+}

--- a/src/components/buttonArrow.ts
+++ b/src/components/buttonArrow.ts
@@ -1,30 +1,24 @@
 /**
  * Button の末尾矢印を href から決める純粋関数。
  *
- * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう矢印を付ける。
- * - 内部ページ (/...): → (サイト内で次のページへ前進)
- * - 外部リンク (http...): ↗ (別タブ・外部サイトへ。SiteHeader の外部リンク表記と統一)
- * - 同一ページ内アンカー (#...): なし (ページ遷移ではなくスクロールのため)
+ * 別ページへ遷移するボタンには「遷移する」ことが直感的に伝わるよう矢印アイコンを付ける。
+ * - 内部ページ (/...): 'internal' → 短い右矢印 (サイト内で次のページへ前進)
+ * - 外部リンク (http...): 'external' → 四角から斜めに飛び出す矢印 (別タブ・外部サイトへ)
+ * - 同一ページ内アンカー (#...): null (ページ遷移ではなくスクロールのため矢印なし)
  *
  * `override` を渡すと自動判定を上書きできる (true=矢印あり / false=矢印なし)。
  * 「戻る」など前進の意味にそぐわないボタンは呼び出し側で false を指定する。
+ * (アイコンの実体は Button.astro の SVG。ここでは種別のみ決める)
  */
-export type ButtonArrow = {
-  /** 外部リンク (別タブ) かどうか */
-  external: boolean
-  /** 表示するグリフ */
-  glyph: '→' | '↗'
-}
+export type ButtonArrowKind = 'internal' | 'external'
 
 export function resolveButtonArrow(
   href: string,
   override?: boolean,
-): ButtonArrow | null {
+): ButtonArrowKind | null {
   const external = href.startsWith('http')
   const anchor = href.startsWith('#')
   const showArrow = override ?? !anchor
   if (!showArrow) return null
-  return external
-    ? { external: true, glyph: '↗' }
-    : { external: false, glyph: '→' }
+  return external ? 'external' : 'internal'
 }

--- a/src/components/buttonArrow.ts
+++ b/src/components/buttonArrow.ts
@@ -12,13 +12,21 @@
  */
 export type ButtonArrowKind = 'internal' | 'external'
 
+/**
+ * 外部リンク (別タブで開く) か判定する。
+ * startsWith('http') だと 'http-status' のような相対パスも拾うため、
+ * プロトコル付き (http:// または https://) のみを外部とみなす。
+ */
+export function isExternalHref(href: string): boolean {
+  return /^https?:\/\//.test(href)
+}
+
 export function resolveButtonArrow(
   href: string,
   override?: boolean,
 ): ButtonArrowKind | null {
-  const external = href.startsWith('http')
   const anchor = href.startsWith('#')
   const showArrow = override ?? !anchor
   if (!showArrow) return null
-  return external ? 'external' : 'internal'
+  return isExternalHref(href) ? 'external' : 'internal'
 }

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -20,7 +20,7 @@ import Button from '~/components/Button.astro'
         移動または削除された可能性があります。トップページからお探しください。
       </p>
       <div class="mt-8 flex flex-wrap justify-center gap-3">
-        <Button href="/" variant="outline">トップへ戻る</Button>
+        <Button href="/" variant="outline" arrow={false}>トップへ戻る</Button>
         <Button href="/purpose">活動を知る</Button>
       </div>
     </Card>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -99,7 +99,7 @@ const heading = postExcerpt(post.body, 40) || formatPostDate(post.data.date)
             class="group rounded-2xl border border-primary/10 bg-surface px-5 py-4 transition-shadow hover:shadow-md"
           >
             <span class="flex items-center gap-1 text-xs text-body/60">
-              <ArrowIcon class="h-[1.1em] w-[1.1em] -scale-x-100 transition-transform group-hover:-translate-x-0.5 motion-reduce:transition-none" />
+              <ArrowIcon class="h-[1.1em] w-[1.1em] -scale-x-100 transition-transform motion-safe:group-hover:-translate-x-0.5" />
               新しい記事
             </span>
             <span class="mt-1 block leading-relaxed text-primary">
@@ -118,7 +118,7 @@ const heading = postExcerpt(post.body, 40) || formatPostDate(post.data.date)
           >
             <span class="flex items-center justify-end gap-1 text-xs text-body/60">
               古い記事
-              <ArrowIcon class="h-[1.1em] w-[1.1em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
+              <ArrowIcon class="h-[1.1em] w-[1.1em] transition-transform motion-safe:group-hover:translate-x-0.5" />
             </span>
             <span class="mt-1 block leading-relaxed text-primary">
               {postExcerpt(older.body, 36) || formatPostDate(older.data.date)}

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -5,6 +5,7 @@ import BaseLayout from '~/layouts/BaseLayout.astro'
 import Container from '~/components/Container.astro'
 import Button from '~/components/Button.astro'
 import NewsCta from '~/components/NewsCta.astro'
+import ArrowIcon from '~/components/ArrowIcon.astro'
 import { formatPostDate } from '~/components/postDate'
 import { postExcerpt } from '~/components/postExcerpt'
 
@@ -97,7 +98,10 @@ const heading = postExcerpt(post.body, 40) || formatPostDate(post.data.date)
             href={`/news/${newer.id}`}
             class="group rounded-2xl border border-primary/10 bg-surface px-5 py-4 transition-shadow hover:shadow-md"
           >
-            <span class="block text-xs text-body/60">← 新しい記事</span>
+            <span class="flex items-center gap-1 text-xs text-body/60">
+              <ArrowIcon class="h-[1.1em] w-[1.1em] -scale-x-100 transition-transform group-hover:-translate-x-0.5 motion-reduce:transition-none" />
+              新しい記事
+            </span>
             <span class="mt-1 block leading-relaxed text-primary">
               {postExcerpt(newer.body, 36) || formatPostDate(newer.data.date)}
             </span>
@@ -112,7 +116,10 @@ const heading = postExcerpt(post.body, 40) || formatPostDate(post.data.date)
             href={`/news/${older.id}`}
             class="group rounded-2xl border border-primary/10 bg-surface px-5 py-4 text-right transition-shadow hover:shadow-md"
           >
-            <span class="block text-xs text-body/60">古い記事 →</span>
+            <span class="flex items-center justify-end gap-1 text-xs text-body/60">
+              古い記事
+              <ArrowIcon class="h-[1.1em] w-[1.1em] transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
+            </span>
             <span class="mt-1 block leading-relaxed text-primary">
               {postExcerpt(older.body, 36) || formatPostDate(older.data.date)}
             </span>


### PR DESCRIPTION
別ページへ遷移するボタンに「遷移する」ことが直感的に伝わるよう
末尾へ矢印を付与する。

- 内部ページ (/...): → (サイト内で次のページへ前進)。ホバーで右へ微動
- 外部リンク (http...): ↗ (別タブ。SiteHeader の外部リンク表記と統一)
- 同一ページ内アンカー (#...): 矢印なし (遷移ではなくスクロールのため)
- arrow prop で上書き可。「戻る」など前進にそぐわないボタンは
  arrow={false} で無効化 (404 / ComingSoon)

判定ロジックは純粋関数 buttonArrow.ts に分離し Vitest で検証。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VnFSqvYb42GruNoxc7X58w