### PR TITLE
fix(buttonArrow): 外部リンク判定で大文字スキーム・前後空白を正規化

### DIFF
--- a/src/components/buttonArrow.test.ts
+++ b/src/components/buttonArrow.test.ts
@@ -49,4 +49,11 @@ describe('resolveButtonArrow', () => {
     expect(resolveButtonArrow('#p1', true)).toBe('internal')
     expect(resolveButtonArrow('https://example.com', true)).toBe('external')
   })
+
+  it('大文字スキーム・前後空白を含む href も正規化して判定する', () => {
+    expect(resolveButtonArrow('HTTPS://example.com')).toBe('external')
+    expect(resolveButtonArrow('  https://example.com  ')).toBe('external')
+    expect(resolveButtonArrow('  /join  ')).toBe('internal')
+    expect(resolveButtonArrow('  #p1  ')).toBeNull()
+  })
 })

--- a/src/components/buttonArrow.test.ts
+++ b/src/components/buttonArrow.test.ts
@@ -14,6 +14,13 @@ describe('isExternalHref', () => {
     expect(isExternalHref('http-status')).toBe(false)
     expect(isExternalHref('/httpie')).toBe(false)
   })
+
+  it('大文字スキーム・前後空白を正規化して判定する', () => {
+    expect(isExternalHref('HTTPS://example.com')).toBe(true)
+    expect(isExternalHref('Http://example.com')).toBe(true)
+    expect(isExternalHref('  https://example.com  ')).toBe(true)
+    expect(isExternalHref('  /join  ')).toBe(false)
+  })
 })
 
 describe('resolveButtonArrow', () => {

--- a/src/components/buttonArrow.ts
+++ b/src/components/buttonArrow.ts
@@ -16,17 +16,19 @@ export type ButtonArrowKind = 'internal' | 'external'
  * 外部リンク (別タブで開く) か判定する。
  * startsWith('http') だと 'http-status' のような相対パスも拾うため、
  * プロトコル付き (http:// または https://) のみを外部とみなす。
+ * 大文字スキーム (HTTPS://) や前後空白も拾えるよう i フラグ + trim で正規化する。
  */
 export function isExternalHref(href: string): boolean {
-  return /^https?:\/\//.test(href)
+  return /^https?:\/\//i.test(href.trim())
 }
 
 export function resolveButtonArrow(
   href: string,
   override?: boolean,
 ): ButtonArrowKind | null {
-  const anchor = href.startsWith('#')
+  const normalizedHref = href.trim()
+  const anchor = normalizedHref.startsWith('#')
   const showArrow = override ?? !anchor
   if (!showArrow) return null
-  return isExternalHref(href) ? 'external' : 'internal'
+  return isExternalHref(normalizedHref) ? 'external' : 'internal'
 }


### PR DESCRIPTION
## 概要

PR #192（ボタン/リンクの矢印アイコン）のフォローアップです。外部リンク判定 `isExternalHref` を堅牢化します。

`isExternalHref` は矢印の種別判定（内部 → / 外部の別タブ記号）と `Button.astro` の `target="_blank"` 付与の両方で使われる共通判定です。これまでの `/^https?:\/\//` だと以下を内部リンク扱いしてしまう可能性がありました。

- 大文字スキーム: `HTTPS://...` / `Http://...`
- 前後に空白を含む href: `"  https://...  "`

## 変更内容

```diff
-  return /^https?:\/\//.test(href)
+  return /^https?:\/\//i.test(href.trim())
```

`resolveButtonArrow` 側も `href.trim()` で正規化してからアンカー/外部を判定するようにしました。

- `i` フラグ: 大文字スキームを許容
- `trim()`: 前後空白を除去
- `http-status` のような相対パスを外部と誤検知しない挙動は維持

## テスト

`buttonArrow.test.ts` に大文字スキーム・前後空白のケースを追加（全 8 ケース pass）。lint / format / typecheck / test すべて green です。

> 実害の観点では、現状サイト内の href はすべて小文字リテラルで前後空白もないため挙動は変わりませんが、共通ユーティリティの堅牢性向上です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnFSqvYb42GruNoxc7X58w)_