### PR TITLE
アクセス解析 (Google Analytics / gtag.js) を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - run: npm run build
         env:
           PDFJS_EXPRESS_VIEWER: ${{ secrets.PDFJS_EXPRESS_VIEWER }}
+          GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
 
   # 実ブラウザ E2E (jsdom では検証できない重なり順などの回帰確認)
   e2e:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,11 +335,12 @@ const events = defineCollection({
 
 ## 環境変数
 
-| 変数名                 | 用途                                    |
-| ---------------------- | --------------------------------------- |
-| `PDFJS_EXPRESS_VIEWER` | PDF.js Express ビューワーライセンスキー |
+| 変数名                 | 用途                                                                                                                                               |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PDFJS_EXPRESS_VIEWER` | PDF.js Express ビューワーライセンスキー                                                                                                            |
+| `GA_MEASUREMENT_ID`    | Google Analytics 測定 ID（例: `G-XXXXXXXXXX`）。`BaseLayout.astro` が設定時のみ gtag.js を出力。未設定なら計測タグなし（ローカル開発・プレビュー） |
 
-GitHub Actions の CI でも参照するため、Cloudflare ダッシュボードに加えて GitHub Secrets にも登録する。
+GitHub Actions の CI でも参照するため、Cloudflare ダッシュボードに加えて GitHub Secrets にも登録する。`GA_MEASUREMENT_ID` は秘匿情報ではなく公開される ID のため、Cloudflare では「変数」、CI では GitHub Actions の Variables（`vars`）として登録する。
 
 ## 開発コマンド
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ npm run preview # ビルド成果物のローカル確認
 | 変数名                                             | 用途                                    | 状態               |
 | -------------------------------------------------- | --------------------------------------- | ------------------ |
 | `PDFJS_EXPRESS_VIEWER`                             | PDF.js Express ビューワーライセンスキー | 現行               |
+| `GA_MEASUREMENT_ID`                                | Google Analytics 測定 ID（gtag.js）     | 現行               |
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | Phase 4 で追加予定 |
 | `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | Phase 5 で追加予定 |
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,11 @@ const fullTitle = title
   ? `${title} | 一般社団法人遠山郷応援会`
   : '一般社団法人遠山郷応援会'
 const currentPath = Astro.url.pathname
+
+// アクセス解析 (Google Analytics / gtag.js)。測定 ID は Cloudflare の環境変数
+// GA_MEASUREMENT_ID で設定する。未設定 (ローカル開発・プレビュー) では計測タグを
+// 出力しないため、開発中のアクセスが本番の解析に混ざらない。
+const gaMeasurementId = import.meta.env.GA_MEASUREMENT_ID
 ---
 
 <!doctype html>
@@ -27,6 +32,25 @@ const currentPath = Astro.url.pathname
     </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{fullTitle}</title>
+    {
+      /* Google tag (gtag.js)。GA_MEASUREMENT_ID が設定されているときのみ出力する。 */
+      gaMeasurementId && (
+        <Fragment>
+          <script
+            is:inline
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
+          />
+          <script
+            is:inline
+            set:html={`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${gaMeasurementId}');`}
+          />
+        </Fragment>
+      )
+    }
     <!-- タイポグラフィ: 見出し Noto Serif JP / 本文 Noto Sans JP (light 基調) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
BaseLayout.astro に gtag.js を組み込み、全ページでアクセス解析を行う。
測定 ID は環境変数 GA_MEASUREMENT_ID から読み込み、設定時のみタグを出力する。
未設定のローカル開発・プレビューでは計測タグを出力しないため、開発中の
アクセスが本番解析に混ざらない。

- GA_MEASUREMENT_ID は公開される ID のため Cloudflare では「変数」、
  CI では GitHub Actions の Variables (vars) として登録する想定
- ci.yml の build ジョブに GA_MEASUREMENT_ID を追加
- CLAUDE.md / README.md の環境変数表を更新

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BuRmESHqaC9bgp6arPmZee