### PR TITLE
Configure Worker URLs: disable workers.dev for production, enable preview URLs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,11 @@
 name = "tohyamago"
 compatibility_date = "2026-01-01"
 
+# プロダクション環境はカスタムドメインでのみ公開し、workers.dev のルートは無効化する
+workers_dev = false
+# プレビューデプロイは workers.dev のサブドメインで一意な URL を発行する
+preview_urls = true
+
 [build]
 command = "npm run build"
 


### PR DESCRIPTION
プロダクション環境はカスタムドメインのみで公開し、プレビューは workers.dev
サブドメインでアクセスできるようにする。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ELM6z5QcLoz4eoGjHdfb9