### PR TITLE
Build-time environment variable branching for production/preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
   # プレビュー/本番ビルドが検証するため、ここでは Cloudflare が自動ビルドしない
   # フォーク由来の PR のときだけ実行し、二重ビルドを避ける。
   build:
+    name: build
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
-          PDFJS_EXPRESS_VIEWER: ${{ secrets.PDFJS_EXPRESS_VIEWER }}
+          PDFJS_EXPRESS_VIEWER: ${{ vars.PDFJS_EXPRESS_VIEWER }}
           GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
 
   # 実ブラウザ E2E (jsdom では検証できない重なり順などの回帰確認)
@@ -86,4 +86,4 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
         env:
-          PDFJS_EXPRESS_VIEWER: ${{ secrets.PDFJS_EXPRESS_VIEWER }}
+          PDFJS_EXPRESS_VIEWER: ${{ vars.PDFJS_EXPRESS_VIEWER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # フルビルド検証。同一リポジトリのブランチ/PR と main への push は Cloudflare の
+  # プレビュー/本番ビルドが検証するため、ここでは Cloudflare が自動ビルドしない
+  # フォーク由来の PR のときだけ実行し、二重ビルドを避ける。
   build:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-        env:
-          PDFJS_EXPRESS_VIEWER: ${{ vars.PDFJS_EXPRESS_VIEWER }}
-          GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
 
   # 実ブラウザ E2E (jsdom では検証できない重なり順などの回帰確認)
   e2e:
@@ -85,5 +82,3 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
-        env:
-          PDFJS_EXPRESS_VIEWER: ${{ vars.PDFJS_EXPRESS_VIEWER }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,26 @@
 
 Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudflare ダッシュボードの GitHub 連携 (Workers Builds)** を使用し、`main` への push や PR の作成で自動的にビルド・公開される。GitHub Actions (`ci.yml`) は品質チェック (Lint / Format / 型チェック / テスト) とビルド検証を行う CI として動作し、デプロイは行わない。
 
+### 環境の切り分け (Wrangler Environments)
+
+本番環境とプレビュー環境で環境変数を切り分けるため、**Wrangler Environments** を使う。Cloudflare ダッシュボードのビルド設定はトリガー単位で本番/プレビューの変数を分けにくいため、`wrangler.toml` に環境の枠 (本番＝トップレベル、プレビュー＝`[env.preview]`) を定義し、それぞれを別 Worker としてデプロイする。
+
+| 環境       | Worker 名           | wrangler.toml       | デプロイ/ビルドコマンド (ダッシュボード)  | 公開先                   |
+| ---------- | ------------------- | ------------------- | ----------------------------------------- | ------------------------ |
+| 本番       | `tohyamago`         | トップレベル (既定) | `npm run build`（`--env` なし＝既定環境） | カスタムドメイン         |
+| プレビュー | `tohyamago-preview` | `[env.preview]`     | `--env preview` を付けてビルド/デプロイ   | workers.dev サブドメイン |
+
+- `vars` は環境間で**継承されない**ため環境ごとに設定するが、`build` / `assets` は**継承される**。値は **Cloudflare ダッシュボードの各 Worker (Settings > Variables)** で管理し、`wrangler.toml` には環境の枠だけを置く。
+- これにより、**本番 Worker (`tohyamago`) にだけ `GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` を設定**すれば、プレビューには計測タグ等が出力されない（「本番のみ設定」を実現）。
+- 今後 Stripe / Clerk のキーを追加する際も、同じく本番 Worker とプレビュー Worker のダッシュボードで別々の値を設定して切り分ける。
+
 ### Cloudflare ダッシュボード側の設定
 
-- Build command: `npm run build`
-- Build output directory: `dist` (`wrangler.toml` の `pages_build_output_dir` でも指定済み)
+- Build command: `npm run build`（プレビュー Worker は `--env preview` を付ける）
+- Build output directory: `dist`（`wrangler.toml` の `[assets]` でも指定済み）
 - Root directory: `/`
 - Node version: 22
-- 環境変数: `PDFJS_EXPRESS_VIEWER`
+- ビルド時の環境変数 (`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER`) は各 Worker の Settings > Variables で設定（本番 Worker のみ）
 
 ## 技術スタック
 
@@ -340,7 +353,12 @@ const events = defineCollection({
 | `PDFJS_EXPRESS_VIEWER` | PDF.js Express ビューワーライセンスキー                                                                                                            |
 | `GA_MEASUREMENT_ID`    | Google Analytics 測定 ID（例: `G-XXXXXXXXXX`）。`BaseLayout.astro` が設定時のみ gtag.js を出力。未設定なら計測タグなし（ローカル開発・プレビュー） |
 
-GitHub Actions の CI でも参照するため、Cloudflare ダッシュボードに加えて GitHub Secrets にも登録する。`GA_MEASUREMENT_ID` は秘匿情報ではなく公開される ID のため、Cloudflare では「変数」、CI では GitHub Actions の Variables（`vars`）として登録する。
+いずれも秘匿情報ではない（`GA_MEASUREMENT_ID` は公開される測定 ID、`PDFJS_EXPRESS_VIEWER` はドメイン固定のビューワーキー）ため、**シークレットではなく通常の「変数」として扱う**。
+
+- **デプロイ時（Cloudflare）**: Wrangler Environments の各 Worker のビルド変数として設定する（上記「環境の切り分け」参照）。本番 Worker (`tohyamago`) のみに設定し、プレビュー Worker (`tohyamago-preview`) には設定しない。
+- **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E でも参照するため、GitHub Actions の **Variables（`vars`）** に登録する（Secrets ではない）。`vars.GA_MEASUREMENT_ID` / `vars.PDFJS_EXPRESS_VIEWER` を参照する。
+
+> 今後追加する Stripe / Clerk のシークレットキーは秘匿情報のため扱いが異なる。デプロイ時は各 Worker のダッシュボードでシークレットとして本番/プレビュー別々に設定し、CI で必要なものは GitHub Secrets に登録する。
 
 ## 開発コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ const events = defineCollection({
 いずれも秘匿情報ではない（`GA_MEASUREMENT_ID` は公開される測定 ID、`PDFJS_EXPRESS_VIEWER` はドメイン固定のビューワーキー）ため、**シークレットではなく通常の「変数」として扱う**。
 
 - **デプロイ時（Cloudflare）**: 静的生成でビルド時に HTML へ焼き込むため、**Settings > Build > 「Build variables and secrets」**（＝ビルド変数。ランタイム用の Variables & Secrets ではない）に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` の形で登録し、ビルド時にブランチで出し分ける（上記「環境変数の本番 / プレビュー切り分け」参照）。プレビューに出したくない変数は `_PREVIEW` を未設定にする。
-- **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E でも参照するため、GitHub Actions の **Variables（`vars`）** に登録する（Secrets ではない）。`vars.GA_MEASUREMENT_ID` / `vars.PDFJS_EXPRESS_VIEWER` を素の名前で渡す（`resolveBuildEnv` は素の名前を最優先する）。
+- **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E は値を必要としない（テストが GA/PDF ビューワーの値に依存しないため）。素の名前が未設定なら `import.meta.env.*` は undefined になるだけでビルドは成功する。必要になった場合のみ GitHub Actions の **Variables（`vars`）** に素の名前で登録する（`resolveBuildEnv` は素の名前を最優先する）。
 
 > 今後追加する Stripe / Clerk のシークレットキーは秘匿情報のため扱いが異なる。ビルド変数には置かず（公開リポジトリの PR ビルドにも見えてしまう）、ランタイムのシークレットとして本番/プレビュー別々に設定し、CI で必要なものは GitHub Secrets に登録する。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,28 +6,24 @@
 
 Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudflare ダッシュボードの GitHub 連携 (Workers Builds)** を使用し、`main` への push や PR の作成で自動的にビルド・公開される。GitHub Actions (`ci.yml`) は品質チェック (Lint / Format / 型チェック / テスト) とビルド検証を行う CI として動作し、デプロイは行わない。
 
-### 環境の切り分け (Wrangler Environments)
+### 環境変数の本番 / プレビュー切り分け (ビルド時にブランチ判定)
 
-本番環境とプレビュー環境で環境変数を切り分けるため、**Wrangler Environments** を使う。Cloudflare ダッシュボードのビルド設定はトリガー単位で本番/プレビューの変数を分けにくいため、`wrangler.toml` に環境の枠 (本番＝トップレベル、プレビュー＝`[env.preview]`) を定義し、それぞれを別 Worker としてデプロイする。
-
-| 環境       | Worker 名           | wrangler.toml       | デプロイ/ビルドコマンド (ダッシュボード)  | 公開先                   |
-| ---------- | ------------------- | ------------------- | ----------------------------------------- | ------------------------ |
-| 本番       | `tohyamago`         | トップレベル (既定) | `npm run build`（`--env` なし＝既定環境） | カスタムドメイン         |
-| プレビュー | `tohyamago-preview` | `[env.preview]`     | `--env preview` を付けてビルド/デプロイ   | workers.dev サブドメイン |
+単一 Worker (`tohyamago`) のまま、本番ブランチ (`main`) のビルドとプレビュー (PR / 非本番ブランチ) のビルドで **ビルド時変数を出し分ける**。Cloudflare ダッシュボードのビルド設定はトリガー単位で本番/プレビューの値を分けにくいため、**両方の値をビルド変数に登録しておき、ビルド時にブランチを見て選ぶ**方式を採る。
 
 - このサイトは Astro の静的生成で、`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` は **ビルド時**に `import.meta.env` 経由で HTML へ焼き込む。ランタイムに Worker スクリプトは無く (assets のみ) `[vars]` は読まれないため、これらは Cloudflare の **ビルド変数** として設定する。
   - Cloudflare には 2 系統あり混同しやすい: **ビルド時変数** = ダッシュボードの **Settings > Build > 「Build variables and secrets」**（`npm run build` の実行環境にのみ注入、ランタイム不可）／**ランタイム変数** = Settings > Variables & Secrets（＝`wrangler.toml` の `[vars]`、デプロイ後の Worker が `env.X` で読む）。本サイトが使うのは前者。
-  - ビルド変数も **Worker (Git ビルド接続) ごと**に分かれるため、`wrangler.toml` には環境の枠だけを置き、値は各 Worker のダッシュボードで管理する。
-- これにより、**本番 Worker (`tohyamago`) のビルド変数にだけ `GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` を設定**すれば、プレビューには計測タグ等が出力されない（「本番のみ設定」を実現）。
-- 今後 Stripe / Clerk のキーを追加する際も、同じく本番 Worker とプレビュー Worker のダッシュボードで別々の値を設定して切り分ける（サーバー側で実行する秘匿キーはランタイムのシークレットとして、ビルド時に必要な公開キー等はビルド変数として、用途に応じて使い分ける）。
+- **設定方法**: ビルド変数に `GA_MEASUREMENT_ID_PRODUCTION` / `GA_MEASUREMENT_ID_PREVIEW`（および `PDFJS_EXPRESS_VIEWER_PRODUCTION` / `..._PREVIEW`）を登録する。Cloudflare がビルド時に注入する `WORKERS_CI_BRANCH` を見て、`main` なら `_PRODUCTION`、それ以外なら `_PREVIEW` を採用し、素の名前 (`GA_MEASUREMENT_ID` 等) に解決する。**プレビューに値を出したくない変数は `_PREVIEW` を未設定にすれば、その変数は注入されない**（例: プレビューには計測タグが出ない）。
+- 解決ロジックは純粋関数 `src/buildEnv.ts`（`resolveBuildEnv`）に分離し Vitest でテストする。`astro.config.mjs` が読み込み時に `process.env` へ反映するため、`BaseLayout.astro` / `articles.astro` 側は従来どおり `import.meta.env.<NAME>` を読むだけでよい。
+- 素の名前 (`GA_MEASUREMENT_ID`) が直接設定されていればそれを最優先する（CI のビルド検証や手動上書き・ローカル開発の `.env` 用）。
+- 今後 Stripe / Clerk を追加する際の住み分け: **ビルド時に埋め込む公開キー**（publishable key 等）は同じく `_PRODUCTION` / `_PREVIEW` のビルド変数で出し分ける。**サーバー側で使う秘密鍵**はビルド変数に置かず（公開リポジトリの PR ビルドにも値が見えてしまうため）、ランタイムのシークレットとして扱う。
 
 ### Cloudflare ダッシュボード側の設定
 
-- Build command: `npm run build`（プレビュー Worker は `--env preview` を付ける）
+- Build command: `npm run build`
 - Build output directory: `dist`（`wrangler.toml` の `[assets]` でも指定済み）
 - Root directory: `/`
 - Node version: 22
-- ビルド時の環境変数 (`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER`) は各 Worker の **Settings > Build > 「Build variables and secrets」** で設定（本番 Worker のみ。ランタイム用の Variables & Secrets ではない）
+- ビルド時の環境変数は **Settings > Build > 「Build variables and secrets」** に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` の形で登録（ランタイム用の Variables & Secrets ではない）。PR / 非本番ブランチも自動ビルドするため、非本番ブランチビルドを有効化しておく。
 
 ## 技術スタック
 
@@ -104,6 +100,8 @@ tohyamago/
 │   │   ├── image-fade-in.test.ts # image-fade-in のテスト (Vitest, jsdom)
 │   │   └── PdfViewer.tsx       # PDF.js Express ラッパー (React, client:only)
 │   ├── content.config.ts       # Content Collection スキーマ (posts / crops / events)
+│   ├── buildEnv.ts             # ビルド時変数を本番/プレビューで出し分ける純粋関数 (astro.config.mjs が利用)
+│   ├── buildEnv.test.ts        # buildEnv のテスト (Vitest)
 │   ├── content/
 │   │   ├── posts/              # 記事 (Markdown) と添付画像
 │   │   ├── crops/              # 農作業カレンダーの作物・作業データ (新規, YAML)
@@ -357,10 +355,10 @@ const events = defineCollection({
 
 いずれも秘匿情報ではない（`GA_MEASUREMENT_ID` は公開される測定 ID、`PDFJS_EXPRESS_VIEWER` はドメイン固定のビューワーキー）ため、**シークレットではなく通常の「変数」として扱う**。
 
-- **デプロイ時（Cloudflare）**: 静的生成でビルド時に HTML へ焼き込むため、各 Worker の **Settings > Build > 「Build variables and secrets」**（＝ビルド変数。ランタイム用の Variables & Secrets ではない）に設定する（上記「環境の切り分け」参照）。本番 Worker (`tohyamago`) のみに設定し、プレビュー Worker (`tohyamago-preview`) には設定しない。
-- **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E でも参照するため、GitHub Actions の **Variables（`vars`）** に登録する（Secrets ではない）。`vars.GA_MEASUREMENT_ID` / `vars.PDFJS_EXPRESS_VIEWER` を参照する。
+- **デプロイ時（Cloudflare）**: 静的生成でビルド時に HTML へ焼き込むため、**Settings > Build > 「Build variables and secrets」**（＝ビルド変数。ランタイム用の Variables & Secrets ではない）に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` の形で登録し、ビルド時にブランチで出し分ける（上記「環境変数の本番 / プレビュー切り分け」参照）。プレビューに出したくない変数は `_PREVIEW` を未設定にする。
+- **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E でも参照するため、GitHub Actions の **Variables（`vars`）** に登録する（Secrets ではない）。`vars.GA_MEASUREMENT_ID` / `vars.PDFJS_EXPRESS_VIEWER` を素の名前で渡す（`resolveBuildEnv` は素の名前を最優先する）。
 
-> 今後追加する Stripe / Clerk のシークレットキーは秘匿情報のため扱いが異なる。デプロイ時は各 Worker のダッシュボードでシークレットとして本番/プレビュー別々に設定し、CI で必要なものは GitHub Secrets に登録する。
+> 今後追加する Stripe / Clerk のシークレットキーは秘匿情報のため扱いが異なる。ビルド変数には置かず（公開リポジトリの PR ビルドにも見えてしまう）、ランタイムのシークレットとして本番/プレビュー別々に設定し、CI で必要なものは GitHub Secrets に登録する。
 
 ## 開発コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,11 @@ Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudf
 | 本番       | `tohyamago`         | トップレベル (既定) | `npm run build`（`--env` なし＝既定環境） | カスタムドメイン         |
 | プレビュー | `tohyamago-preview` | `[env.preview]`     | `--env preview` を付けてビルド/デプロイ   | workers.dev サブドメイン |
 
-- `vars` は環境間で**継承されない**ため環境ごとに設定するが、`build` / `assets` は**継承される**。値は **Cloudflare ダッシュボードの各 Worker (Settings > Variables)** で管理し、`wrangler.toml` には環境の枠だけを置く。
-- これにより、**本番 Worker (`tohyamago`) にだけ `GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` を設定**すれば、プレビューには計測タグ等が出力されない（「本番のみ設定」を実現）。
-- 今後 Stripe / Clerk のキーを追加する際も、同じく本番 Worker とプレビュー Worker のダッシュボードで別々の値を設定して切り分ける。
+- このサイトは Astro の静的生成で、`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` は **ビルド時**に `import.meta.env` 経由で HTML へ焼き込む。ランタイムに Worker スクリプトは無く (assets のみ) `[vars]` は読まれないため、これらは Cloudflare の **ビルド変数** として設定する。
+  - Cloudflare には 2 系統あり混同しやすい: **ビルド時変数** = ダッシュボードの **Settings > Build > 「Build variables and secrets」**（`npm run build` の実行環境にのみ注入、ランタイム不可）／**ランタイム変数** = Settings > Variables & Secrets（＝`wrangler.toml` の `[vars]`、デプロイ後の Worker が `env.X` で読む）。本サイトが使うのは前者。
+  - ビルド変数も **Worker (Git ビルド接続) ごと**に分かれるため、`wrangler.toml` には環境の枠だけを置き、値は各 Worker のダッシュボードで管理する。
+- これにより、**本番 Worker (`tohyamago`) のビルド変数にだけ `GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER` を設定**すれば、プレビューには計測タグ等が出力されない（「本番のみ設定」を実現）。
+- 今後 Stripe / Clerk のキーを追加する際も、同じく本番 Worker とプレビュー Worker のダッシュボードで別々の値を設定して切り分ける（サーバー側で実行する秘匿キーはランタイムのシークレットとして、ビルド時に必要な公開キー等はビルド変数として、用途に応じて使い分ける）。
 
 ### Cloudflare ダッシュボード側の設定
 
@@ -25,7 +27,7 @@ Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudf
 - Build output directory: `dist`（`wrangler.toml` の `[assets]` でも指定済み）
 - Root directory: `/`
 - Node version: 22
-- ビルド時の環境変数 (`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER`) は各 Worker の Settings > Variables で設定（本番 Worker のみ）
+- ビルド時の環境変数 (`GA_MEASUREMENT_ID` / `PDFJS_EXPRESS_VIEWER`) は各 Worker の **Settings > Build > 「Build variables and secrets」** で設定（本番 Worker のみ。ランタイム用の Variables & Secrets ではない）
 
 ## 技術スタック
 
@@ -355,7 +357,7 @@ const events = defineCollection({
 
 いずれも秘匿情報ではない（`GA_MEASUREMENT_ID` は公開される測定 ID、`PDFJS_EXPRESS_VIEWER` はドメイン固定のビューワーキー）ため、**シークレットではなく通常の「変数」として扱う**。
 
-- **デプロイ時（Cloudflare）**: Wrangler Environments の各 Worker のビルド変数として設定する（上記「環境の切り分け」参照）。本番 Worker (`tohyamago`) のみに設定し、プレビュー Worker (`tohyamago-preview`) には設定しない。
+- **デプロイ時（Cloudflare）**: 静的生成でビルド時に HTML へ焼き込むため、各 Worker の **Settings > Build > 「Build variables and secrets」**（＝ビルド変数。ランタイム用の Variables & Secrets ではない）に設定する（上記「環境の切り分け」参照）。本番 Worker (`tohyamago`) のみに設定し、プレビュー Worker (`tohyamago-preview`) には設定しない。
 - **CI（GitHub Actions）**: `ci.yml` のビルド検証・E2E でも参照するため、GitHub Actions の **Variables（`vars`）** に登録する（Secrets ではない）。`vars.GA_MEASUREMENT_ID` / `vars.PDFJS_EXPRESS_VIEWER` を参照する。
 
 > 今後追加する Stripe / Clerk のシークレットキーは秘匿情報のため扱いが異なる。デプロイ時は各 Worker のダッシュボードでシークレットとして本番/プレビュー別々に設定し、CI で必要なものは GitHub Secrets に登録する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## ホスティング
 
-Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudflare ダッシュボードの GitHub 連携 (Workers Builds)** を使用し、`main` への push や PR の作成で自動的にビルド・公開される。GitHub Actions (`ci.yml`) は品質チェック (Lint / Format / 型チェック / テスト) とビルド検証を行う CI として動作し、デプロイは行わない。
+Cloudflare Pages にデプロイする静的サイト。デプロイは **Cloudflare ダッシュボードの GitHub 連携 (Workers Builds)** を使用し、`main` への push や PR の作成で自動的にビルド・公開される。GitHub Actions (`ci.yml`) は品質チェック (Lint / Format / 型チェック / テスト) を行う CI として動作し、デプロイは行わない。フルビルド検証は通常 Cloudflare のプレビュー/本番ビルドが担うため、`ci.yml` の `build` ジョブは **Cloudflare が自動ビルドしないフォーク由来の PR のときだけ**実行する（二重ビルド回避）。
 
 ### 環境変数の本番 / プレビュー切り分け (ビルド時にブランチ判定)
 
@@ -117,7 +117,7 @@ tohyamago/
 │   └── .well-known/
 │       └── apple-developer-merchantid-domain-association
 ├── wrangler.toml               # Cloudflare Pages 設定 (出力ディレクトリ)
-└── .github/workflows/ci.yml    # 品質チェック + ビルド検証 CI (デプロイは Cloudflare 側)
+└── .github/workflows/ci.yml    # 品質チェック CI + フォーク PR のみフルビルド検証 (デプロイは Cloudflare 側)
 ```
 
 ## サイト構成（情報設計）

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ npm run preview # ビルド成果物のローカル確認
 
 - ブランチ運用・デプロイ・ディレクトリ構造・記事追加手順の詳細は [`CLAUDE.md`](./CLAUDE.md) を参照。
 - デプロイは Cloudflare ダッシュボードの GitHub 連携（Workers Builds）。`main` への push / PR 作成で自動ビルド・公開。GitHub Actions (`ci.yml`) はビルド検証のみ。
-- 本番 / プレビューは **Wrangler Environments**（本番＝既定の Worker `tohyamago`、プレビュー＝`[env.preview]` の `tohyamago-preview`）で切り分け、環境変数は各 Worker のダッシュボードで個別管理する。詳細は [`CLAUDE.md` の「環境の切り分け」](./CLAUDE.md) を参照。
+- 本番 / プレビューの環境変数は、単一 Worker のビルド変数に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` を登録し、**ビルド時にブランチ（`WORKERS_CI_BRANCH`）で出し分ける**（純粋関数 `src/buildEnv.ts`）。詳細は [`CLAUDE.md` の「環境変数の本番 / プレビュー切り分け」](./CLAUDE.md) を参照。
 
 ### 環境変数
 
@@ -344,7 +344,7 @@ npm run preview # ビルド成果物のローカル確認
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | シークレット     | Phase 4 で追加予定 |
 | `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | 一部シークレット | Phase 5 で追加予定 |
 
-> 環境変数は本番 / プレビューで切り分ける。本サイトは静的生成のため `PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` は**ビルド時**に必要で、デプロイ時は Wrangler Environments の各 Worker の **Settings > Build「Build variables and secrets」**（ランタイム用の Variables & Secrets ではない）に設定する（本番 Worker のみ）。CI で必要なものは GitHub Actions の Variables（公開可能な変数）または Secrets（秘匿情報）に登録する。両変数とも秘匿情報ではないため変数として扱う。
+> 本サイトは静的生成のため `PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` は**ビルド時**に必要（ランタイム変数ではない）。デプロイ時は Cloudflare の **Settings > Build「Build variables and secrets」** に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` を登録し、ビルド時にブランチで出し分ける（プレビューに出したくない変数は `_PREVIEW` を未設定に）。CI では GitHub Actions の Variables（`vars`、公開可能な変数）に素の名前で登録する。両変数とも秘匿情報ではないため変数として扱い、将来の Stripe/Clerk の秘密鍵はビルド変数に置かずランタイムのシークレットとする。
 
 ### 外部リンク
 

--- a/README.md
+++ b/README.md
@@ -333,17 +333,18 @@ npm run preview # ビルド成果物のローカル確認
 
 - ブランチ運用・デプロイ・ディレクトリ構造・記事追加手順の詳細は [`CLAUDE.md`](./CLAUDE.md) を参照。
 - デプロイは Cloudflare ダッシュボードの GitHub 連携（Workers Builds）。`main` への push / PR 作成で自動ビルド・公開。GitHub Actions (`ci.yml`) はビルド検証のみ。
+- 本番 / プレビューは **Wrangler Environments**（本番＝既定の Worker `tohyamago`、プレビュー＝`[env.preview]` の `tohyamago-preview`）で切り分け、環境変数は各 Worker のダッシュボードで個別管理する。詳細は [`CLAUDE.md` の「環境の切り分け」](./CLAUDE.md) を参照。
 
 ### 環境変数
 
-| 変数名                                             | 用途                                    | 状態               |
-| -------------------------------------------------- | --------------------------------------- | ------------------ |
-| `PDFJS_EXPRESS_VIEWER`                             | PDF.js Express ビューワーライセンスキー | 現行               |
-| `GA_MEASUREMENT_ID`                                | Google Analytics 測定 ID（gtag.js）     | 現行               |
-| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | Phase 4 で追加予定 |
-| `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | Phase 5 で追加予定 |
+| 変数名                                             | 用途                                    | 種別             | 状態               |
+| -------------------------------------------------- | --------------------------------------- | ---------------- | ------------------ |
+| `PDFJS_EXPRESS_VIEWER`                             | PDF.js Express ビューワーライセンスキー | 変数             | 現行               |
+| `GA_MEASUREMENT_ID`                                | Google Analytics 測定 ID（gtag.js）     | 変数             | 現行               |
+| `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | シークレット     | Phase 4 で追加予定 |
+| `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | 一部シークレット | Phase 5 で追加予定 |
 
-> 新規シークレットは Cloudflare ダッシュボードと（CI で必要なら）GitHub Secrets の両方に登録する。
+> 環境変数は本番 / プレビューで切り分ける。デプロイ時は Wrangler Environments の各 Worker のダッシュボードで設定し（本番のみ・プレビューのみを明示）、CI で必要なものは GitHub Actions の Variables（公開可能な変数）または Secrets（秘匿情報）に登録する。`PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` はいずれも秘匿情報ではないため変数として扱う。
 
 ### 外部リンク
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ npm run preview # ビルド成果物のローカル確認
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | シークレット     | Phase 4 で追加予定 |
 | `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | 一部シークレット | Phase 5 で追加予定 |
 
-> 環境変数は本番 / プレビューで切り分ける。デプロイ時は Wrangler Environments の各 Worker のダッシュボードで設定し（本番のみ・プレビューのみを明示）、CI で必要なものは GitHub Actions の Variables（公開可能な変数）または Secrets（秘匿情報）に登録する。`PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` はいずれも秘匿情報ではないため変数として扱う。
+> 環境変数は本番 / プレビューで切り分ける。本サイトは静的生成のため `PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` は**ビルド時**に必要で、デプロイ時は Wrangler Environments の各 Worker の **Settings > Build「Build variables and secrets」**（ランタイム用の Variables & Secrets ではない）に設定する（本番 Worker のみ）。CI で必要なものは GitHub Actions の Variables（公開可能な変数）または Secrets（秘匿情報）に登録する。両変数とも秘匿情報ではないため変数として扱う。
 
 ### 外部リンク
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ npm run preview # ビルド成果物のローカル確認
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` ほか | Stripe 決済                             | シークレット     | Phase 4 で追加予定 |
 | `CLERK_*`（公開鍵・シークレット鍵等）              | Clerk 認証                              | 一部シークレット | Phase 5 で追加予定 |
 
-> 本サイトは静的生成のため `PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` は**ビルド時**に必要（ランタイム変数ではない）。デプロイ時は Cloudflare の **Settings > Build「Build variables and secrets」** に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` を登録し、ビルド時にブランチで出し分ける（プレビューに出したくない変数は `_PREVIEW` を未設定に）。CI では GitHub Actions の Variables（`vars`、公開可能な変数）に素の名前で登録する。両変数とも秘匿情報ではないため変数として扱い、将来の Stripe/Clerk の秘密鍵はビルド変数に置かずランタイムのシークレットとする。
+> 本サイトは静的生成のため `PDFJS_EXPRESS_VIEWER` / `GA_MEASUREMENT_ID` は**ビルド時**に必要（ランタイム変数ではない）。デプロイ時は Cloudflare の **Settings > Build「Build variables and secrets」** に `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` を登録し、ビルド時にブランチで出し分ける（プレビューに出したくない変数は `_PREVIEW` を未設定に）。CI（GitHub Actions）は値に依存しないため未設定でよい（必要時のみ `vars` に素の名前で登録）。両変数とも秘匿情報ではないため変数として扱い、将来の Stripe/Clerk の秘密鍵はビルド変数に置かずランタイムのシークレットとする。
 
 ### 外部リンク
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,13 @@ import { defineConfig } from 'astro/config'
 import react from '@astrojs/react'
 import tailwindcss from '@tailwindcss/vite'
 import remarkBreaks from 'remark-breaks'
+import { resolveBuildEnv } from './src/buildEnv'
+
+// ビルド時変数 (GA_MEASUREMENT_ID / PDFJS_EXPRESS_VIEWER) を本番 / プレビューで
+// 出し分ける。単一 Worker のビルド変数に *_PRODUCTION / *_PREVIEW を登録しておき、
+// Cloudflare が注入する WORKERS_CI_BRANCH を見て素の名前へ解決する。設定後は
+// import.meta.env.GA_MEASUREMENT_ID 等が従来どおり読める。詳細は src/buildEnv.ts。
+Object.assign(process.env, resolveBuildEnv(process.env))
 
 export default defineConfig({
   integrations: [react()],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,14 @@ export default tseslint.config(
     },
   },
 
+  {
+    // ルート直下の設定ファイル (astro/eslint/vitest 等) は Node 環境で実行される
+    files: ['*.{js,mjs,ts}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+
   // Prettier と競合する整形系ルールを無効化 (必ず最後)
   prettier,
 )

--- a/src/buildEnv.test.ts
+++ b/src/buildEnv.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { isProductionBranch, resolveBuildEnv } from './buildEnv'
+
+describe('isProductionBranch', () => {
+  it('main は本番ブランチ', () => {
+    expect(isProductionBranch('main')).toBe(true)
+  })
+
+  it('main 以外・未設定はプレビュー扱い', () => {
+    expect(isProductionBranch('preview')).toBe(false)
+    expect(isProductionBranch('feature/x')).toBe(false)
+    expect(isProductionBranch(undefined)).toBe(false)
+    expect(isProductionBranch('')).toBe(false)
+  })
+})
+
+describe('resolveBuildEnv', () => {
+  it('本番ブランチでは _PRODUCTION を採用する', () => {
+    const resolved = resolveBuildEnv({
+      WORKERS_CI_BRANCH: 'main',
+      GA_MEASUREMENT_ID_PRODUCTION: 'G-PROD',
+      GA_MEASUREMENT_ID_PREVIEW: 'G-PREV',
+      PDFJS_EXPRESS_VIEWER_PRODUCTION: 'key-prod',
+      PDFJS_EXPRESS_VIEWER_PREVIEW: 'key-prev',
+    })
+    expect(resolved).toEqual({
+      GA_MEASUREMENT_ID: 'G-PROD',
+      PDFJS_EXPRESS_VIEWER: 'key-prod',
+    })
+  })
+
+  it('非本番ブランチでは _PREVIEW を採用する', () => {
+    const resolved = resolveBuildEnv({
+      WORKERS_CI_BRANCH: 'some-feature',
+      GA_MEASUREMENT_ID_PRODUCTION: 'G-PROD',
+      GA_MEASUREMENT_ID_PREVIEW: 'G-PREV',
+    })
+    expect(resolved).toEqual({ GA_MEASUREMENT_ID: 'G-PREV' })
+  })
+
+  it('素の名前があれば最優先する (CI・手動上書き用)', () => {
+    const resolved = resolveBuildEnv({
+      WORKERS_CI_BRANCH: 'main',
+      GA_MEASUREMENT_ID: 'G-EXPLICIT',
+      GA_MEASUREMENT_ID_PRODUCTION: 'G-PROD',
+    })
+    expect(resolved.GA_MEASUREMENT_ID).toBe('G-EXPLICIT')
+  })
+
+  it('該当する値が無いキーは結果に含めない (undefined 代入事故の防止)', () => {
+    // プレビューに GA を出さない運用 (_PREVIEW 未設定) を想定
+    const resolved = resolveBuildEnv({
+      WORKERS_CI_BRANCH: 'pr-branch',
+      GA_MEASUREMENT_ID_PRODUCTION: 'G-PROD',
+    })
+    expect(resolved).not.toHaveProperty('GA_MEASUREMENT_ID')
+    expect(resolved).toEqual({})
+  })
+
+  it('keys 引数で対象を限定できる', () => {
+    const resolved = resolveBuildEnv(
+      {
+        WORKERS_CI_BRANCH: 'main',
+        FOO_PRODUCTION: 'foo',
+        BAR_PRODUCTION: 'bar',
+      },
+      ['FOO'],
+    )
+    expect(resolved).toEqual({ FOO: 'foo' })
+  })
+})

--- a/src/buildEnv.ts
+++ b/src/buildEnv.ts
@@ -1,0 +1,44 @@
+// 本番 / プレビューのビルド時環境変数を出し分ける純粋関数。
+//
+// このサイトは単一の Cloudflare Worker (tohyamago) でビルドする。本番ブランチと
+// プレビュー (PR / 非本番ブランチ) のビルドが同じ Worker のビルド変数を共有するため、
+// ビルド時にブランチを見て値を選び分ける。Cloudflare Workers Builds はビルド時に
+// ブランチ名を WORKERS_CI_BRANCH として注入する (本番でも設定される)。
+//
+// 運用: Worker の Settings > Build「Build variables and secrets」に、出し分けたい
+// 変数を `<NAME>_PRODUCTION` / `<NAME>_PREVIEW` の 2 つで登録する。本番ブランチの
+// ビルドでは `_PRODUCTION`、それ以外では `_PREVIEW` を採用する。プレビューに値を
+// 出したくない変数は `_PREVIEW` を未設定にすれば、その変数は注入されない。
+// 素の名前 (例: GA_MEASUREMENT_ID) が既にあればそれを最優先する (CI のビルド検証や
+// 手動上書き用。ローカル開発では .env などで素の名前を使えば従来どおり動く)。
+
+// 本番ビルドとみなすブランチ
+export const PRODUCTION_BRANCH = 'main'
+
+// 本番 / プレビューで出し分けるビルド時変数名
+export const BUILD_ENV_KEYS = [
+  'GA_MEASUREMENT_ID',
+  'PDFJS_EXPRESS_VIEWER',
+] as const
+
+export function isProductionBranch(branch: string | undefined): boolean {
+  return branch === PRODUCTION_BRANCH
+}
+
+// env (通常は process.env) から、ブランチに応じた最終的な値を解決して返す。
+// 戻り値は「素の名前 → 確定値」のマップ。値が無いキーは含めない
+// (undefined を process.env に代入すると "undefined" 文字列になる事故を防ぐ)。
+export function resolveBuildEnv(
+  env: Record<string, string | undefined>,
+  keys: readonly string[] = BUILD_ENV_KEYS,
+): Record<string, string> {
+  const suffix = isProductionBranch(env.WORKERS_CI_BRANCH)
+    ? 'PRODUCTION'
+    : 'PREVIEW'
+  const resolved: Record<string, string> = {}
+  for (const key of keys) {
+    const value = env[key] ?? env[`${key}_${suffix}`]
+    if (value) resolved[key] = value
+  }
+  return resolved
+}

--- a/src/buildEnv.ts
+++ b/src/buildEnv.ts
@@ -21,13 +21,24 @@ export const BUILD_ENV_KEYS = [
   'PDFJS_EXPRESS_VIEWER',
 ] as const
 
+/**
+ * ブランチ名が本番ブランチ (PRODUCTION_BRANCH) かどうかを判定する。
+ * 未設定 (ローカル開発など) やそれ以外のブランチはプレビュー扱い (false)。
+ */
 export function isProductionBranch(branch: string | undefined): boolean {
   return branch === PRODUCTION_BRANCH
 }
 
-// env (通常は process.env) から、ブランチに応じた最終的な値を解決して返す。
-// 戻り値は「素の名前 → 確定値」のマップ。値が無いキーは含めない
-// (undefined を process.env に代入すると "undefined" 文字列になる事故を防ぐ)。
+/**
+ * env (通常は process.env) から、ブランチに応じた最終的な値を解決して返す。
+ * 本番ブランチなら各キーの `_PRODUCTION`、それ以外は `_PREVIEW` を採用し、素の名前が
+ * あればそれを最優先する。戻り値は「素の名前 → 確定値」のマップで、値が無いキーは
+ * 含めない (undefined を process.env に代入すると "undefined" 文字列になる事故を防ぐ)。
+ *
+ * @param env 参照する環境変数 (WORKERS_CI_BRANCH と各キーの値を含む)
+ * @param keys 出し分け対象の変数名。既定は BUILD_ENV_KEYS
+ * @returns 解決済みの「素の名前 → 値」マップ
+ */
 export function resolveBuildEnv(
   env: Record<string, string | undefined>,
   keys: readonly string[] = BUILD_ENV_KEYS,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,18 +1,10 @@
 name = "tohyamago"
 compatibility_date = "2026-01-01"
 
-# プロダクション環境 (トップレベル = デフォルト環境。Worker 名は "tohyamago")。
-# カスタムドメインでのみ公開し、workers.dev のルートは無効化する。
+# プロダクション環境はカスタムドメインでのみ公開し、workers.dev のルートは無効化する
 workers_dev = false
-# プレビュー版デプロイは workers.dev のサブドメインで一意な URL を発行する
+# プレビューデプロイは workers.dev のサブドメインで一意な URL を発行する
 preview_urls = true
-
-# ビルド時の環境変数 (GA_MEASUREMENT_ID / PDFJS_EXPRESS_VIEWER) は
-# Cloudflare ダッシュボードの本番 Worker "tohyamago" 側 (Settings > Variables)
-# でのみ設定する。プレビュー環境 ([env.preview]) には設定しないため、
-# プレビューには計測タグ等が出力されない。値はダッシュボードで管理し、
-# wrangler.toml には環境の枠だけを定義する (vars は環境間で継承されないため
-# 環境ごとにダッシュボードで設定する)。
 
 [build]
 command = "npm run build"
@@ -20,10 +12,3 @@ command = "npm run build"
 [assets]
 directory = "./dist"
 not_found_handling = "404-page"
-
-# プレビュー環境 (PR / 非本番ブランチ)。別 Worker "tohyamago-preview" として
-# デプロイされる (デプロイ/ビルドコマンドに --env preview を付与)。
-# build / assets はトップレベルから継承される (vars は継承されないため、
-# 必要な変数はこの環境の Worker のダッシュボードで個別に設定する)。
-[env.preview]
-workers_dev = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,18 @@
 name = "tohyamago"
 compatibility_date = "2026-01-01"
 
-# プロダクション環境はカスタムドメインでのみ公開し、workers.dev のルートは無効化する
+# プロダクション環境 (トップレベル = デフォルト環境。Worker 名は "tohyamago")。
+# カスタムドメインでのみ公開し、workers.dev のルートは無効化する。
 workers_dev = false
-# プレビューデプロイは workers.dev のサブドメインで一意な URL を発行する
+# プレビュー版デプロイは workers.dev のサブドメインで一意な URL を発行する
 preview_urls = true
+
+# ビルド時の環境変数 (GA_MEASUREMENT_ID / PDFJS_EXPRESS_VIEWER) は
+# Cloudflare ダッシュボードの本番 Worker "tohyamago" 側 (Settings > Variables)
+# でのみ設定する。プレビュー環境 ([env.preview]) には設定しないため、
+# プレビューには計測タグ等が出力されない。値はダッシュボードで管理し、
+# wrangler.toml には環境の枠だけを定義する (vars は環境間で継承されないため
+# 環境ごとにダッシュボードで設定する)。
 
 [build]
 command = "npm run build"
@@ -12,3 +20,10 @@ command = "npm run build"
 [assets]
 directory = "./dist"
 not_found_handling = "404-page"
+
+# プレビュー環境 (PR / 非本番ブランチ)。別 Worker "tohyamago-preview" として
+# デプロイされる (デプロイ/ビルドコマンドに --env preview を付与)。
+# build / assets はトップレベルから継承される (vars は継承されないため、
+# 必要な変数はこの環境の Worker のダッシュボードで個別に設定する)。
+[env.preview]
+workers_dev = true


### PR DESCRIPTION
## Summary

Implement build-time environment variable branching to support separate configurations for production (`main` branch) and preview (PR/non-main branches) builds within a single Cloudflare Worker. This allows the static site to use different values (e.g., GA measurement IDs, PDF viewer keys) depending on the deployment context without duplicating the Worker configuration.

## Key Changes

- **New `src/buildEnv.ts`**: Pure function `resolveBuildEnv()` that resolves build-time variables by examining the `WORKERS_CI_BRANCH` environment variable injected by Cloudflare. Supports three-tier precedence:
  1. Explicit variable name (e.g., `GA_MEASUREMENT_ID`) — for CI overrides and local development
  2. Branch-specific suffix (e.g., `GA_MEASUREMENT_ID_PRODUCTION` or `GA_MEASUREMENT_ID_PREVIEW`)
  3. Omitted if no value exists (prevents `undefined` string injection)

- **New `src/buildEnv.test.ts`**: Comprehensive Vitest test suite covering production/preview branching logic, explicit variable precedence, and selective key resolution.

- **Updated `astro.config.mjs`**: Calls `resolveBuildEnv(process.env)` at config load time to inject resolved variables into `process.env`, making them available to `import.meta.env.*` throughout the build.

- **Updated `ci.yml`**: 
  - Removed environment variable injection from `build` and `e2e` jobs (no longer needed since tests don't depend on GA/PDF viewer values)
  - Added conditional execution to `build` job: only runs on fork-originated PRs (skips redundant builds for same-repo branches/PRs, which Cloudflare already validates)

- **Updated `eslint.config.js`**: Added Node.js globals for root-level config files (`astro.config.mjs`, etc.) to prevent ESLint errors.

- **Documentation updates** (`CLAUDE.md`, `README.md`): Detailed explanation of the branching strategy, Cloudflare build variable setup (`<NAME>_PRODUCTION` / `<NAME>_PREVIEW`), and distinction between build-time variables (Settings > Build) and runtime variables (Settings > Variables & Secrets).

## Implementation Details

- **Cloudflare setup**: Register `GA_MEASUREMENT_ID_PRODUCTION`, `GA_MEASUREMENT_ID_PREVIEW`, `PDFJS_EXPRESS_VIEWER_PRODUCTION`, and `PDFJS_EXPRESS_VIEWER_PREVIEW` in **Settings > Build > "Build variables and secrets"** (not the runtime Variables & Secrets).
- **Preview-only suppression**: Omit the `_PREVIEW` variant for variables that should not appear in preview builds (e.g., GA tracking).
- **Local development**: Use `.env` with the plain variable name (e.g., `GA_MEASUREMENT_ID`) — `resolveBuildEnv` prioritizes explicit names.
- **CI flexibility**: GitHub Actions CI no longer requires these variables; they're only needed if manual build validation is required (register in GitHub Actions `vars` with the plain name).

https://claude.ai/code/session_01CtEiefdaSvekbv4pW2ZdMU