### PR TITLE
fix: zod v4 の非推奨 API を最新の書き方へ更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ const events = defineCollection({
     end: halfMonth,
     category: z.string().default('地域行事'),
     location: z.string().optional(),
-    url: z.string().url().optional(),
+    url: z.url().optional(),
     note: z.string().optional(),
   }),
 })

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
 import { glob } from 'astro/loaders'
+import { z } from 'astro/zod'
 
 const posts = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/posts' }),
@@ -7,7 +8,7 @@ const posts = defineCollection({
     z.object({
       date: z.coerce.date(),
       images: z.array(image()).default([]),
-      sourceUrl: z.string().url().optional(),
+      sourceUrl: z.url().optional(),
     }),
 })
 
@@ -62,7 +63,7 @@ const events = defineCollection({
       end: monthThird,
       category: z.string().default('地域行事'),
       location: z.string().optional(),
-      url: z.string().url().optional(),
+      url: z.url().optional(),
       note: z.string().optional(),
     })
     .refine((event) => event.start <= event.end, {


### PR DESCRIPTION
Astro 7 へのアップグレードで zod が v4 系に更新され、以下が非推奨となった
ため最新 API に追従する。

- astro:content の z 再エクスポートは非推奨 (Astro 7 で削除予定) のため
  astro/zod から import するよう変更
- z.string().url() は非推奨のためトップレベル z.url() を使用

astro check の content.config.ts に対する deprecation 警告が解消される。
lint / format / test (108) / build すべて通過を確認。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PqNMEwQfVpJmgwnHAB3MkR