### PR TITLE
トップ3導線カード: 重複ラベル削除と線画アイコン刷新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,9 +405,10 @@ PDF.js Express ビューワーは `node_modules/@pdftron/pdfjs-express-viewer/pu
   - **バッジ（ラベルピル）の ▲ は廃止**する方針 → 下記「バッジ（ラベルピル）の方針」。
   - ▲ を残す箇所（ロゴ等）の描画は Tailwind の `before:` / `after:` 疑似要素で border-trick / `content` を利用。
 - **バッジ（ラベルピル）の方針**（2026-06 決定。**記録のみ。置換は今後の修正時に段階的に適用**）
-  - 団体名・小ラベルのピルは、ヒーロー (`index.astro`) で作成した **三角なしの濃緑ベタピル**に寄せる。基準スタイル:
+  - 団体名・小ラベルのピルは、ヒーロー (`index.astro`) で作成した **三角なしのベタピル**に寄せる。基準スタイル（標準サイズ）:
     `rounded-full bg-primary-deep px-4 py-1 font-serif text-sm tracking-wide text-white`（＋ `▲` は付けない）。
     - 暗い写真の上に重ねる場合は `ring-1 ring-white/25` と `[text-shadow:0_1px_3px_rgba(15,46,33,0.6)]` を足す。明るい地色の上ではベタのまま（白文字で AA を確保）。`backdrop-blur` はベタ背景には不要。
+    - **コンパクトサイズも許容**する。カードのタイトル行末尾など、見出しに添える小さなステータスピル（例: `JourneyCards.astro` の「なかま募集中」）では、本文・見出しを圧迫しないよう縮めてよい。基準: `rounded-full px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white`（`font-serif` の代わりに `font-medium`、地色は文脈に合わせ `bg-primary-deep` か差し色の `bg-accent-strong` 等）。**三角なし・ベタ塗り・白文字・`rounded-full`** という核は標準サイズと共通で、サイズ（padding / font-size / weight）と地色だけを用途に合わせて変える。
   - 旧スタイル（`bg-sunlight-soft` 等の淡色ピル＋ `before:content-['▲']`、`text-primary-deep` 文字）は順次これへ置換する。
   - 置換対象（アイブロウのラベルピル）: `pages/news.astro` /
     `pages/story.astro` / `pages/products.astro` / `pages/join.astro` /

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -90,26 +90,24 @@ const tints = {
                 : {})}
               class="flex h-full flex-col gap-3 p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              <div class="flex flex-col gap-1">
+              <div class="flex items-center gap-3">
+                <span
+                  aria-hidden="true"
+                  class:list={[
+                    'flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-transform motion-safe:group-hover:-translate-y-0.5',
+                    t.icon,
+                  ]}
+                >
+                  <JourneyIcon name={j.icon} class="h-6 w-6" />
+                </span>
+                <h3 class="font-serif text-xl font-medium text-primary">
+                  {j.title}
+                </h3>
                 {j.featured && (
-                  <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white ms-15">
+                  <span class="inline-flex shrink-0 rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
                     なかま募集中
                   </span>
                 )}
-                <div class="flex items-center gap-3">
-                  <span
-                    aria-hidden="true"
-                    class:list={[
-                      'flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-transform motion-safe:group-hover:-translate-y-0.5',
-                      t.icon,
-                    ]}
-                  >
-                    <JourneyIcon name={j.icon} class="h-6 w-6" />
-                  </span>
-                  <h3 class="font-serif text-xl font-medium text-primary">
-                    {j.title}
-                  </h3>
-                </div>
               </div>
               <p class="grow text-sm leading-relaxed text-body">{j.desc}</p>
               <span

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -8,12 +8,12 @@
  */
 import Card from '~/components/Card.astro'
 import ArrowIcon from '~/components/ArrowIcon.astro'
+import JourneyIcon from '~/components/JourneyIcon.astro'
 
 interface Journey {
   href: string
   external?: boolean
-  emoji: string
-  label: string
+  icon: 'sprout' | 'cup' | 'hands'
   title: string
   desc: string
   cta: string
@@ -25,8 +25,7 @@ interface Journey {
 const journeys: Journey[] = [
   {
     href: '/join',
-    emoji: '🌱',
-    label: '参加する',
+    icon: 'sprout',
     title: '活動に参加する',
     desc: '植え付け・草取り・収穫・お茶摘み。仲間同士で教え合い、地域の方々の力も借りながら進めます。初めての方も、まずは一日、活動に加わってみませんか。',
     cta: 'はじめての方へ',
@@ -35,8 +34,7 @@ const journeys: Journey[] = [
   },
   {
     href: '/products',
-    emoji: '🍵',
-    label: '成果品',
+    icon: 'cup',
     title: '遠山郷の味を買う',
     desc: '下栗芋・蕎麦・大豆・お茶。皆で活動するなかで実った収穫の一部を、この土地ならではの味としてお分けしています。',
     cta: '成果品を見る',
@@ -44,8 +42,7 @@ const journeys: Journey[] = [
   },
   {
     href: '/support',
-    emoji: '🤝',
-    label: '支える',
+    icon: 'hands',
     title: '活動を応援する',
     desc: '寄付や入会で、遠山郷の景観と暮らしを守る活動を支えられます。離れていても、谷とつながる方法があります。',
     cta: '支え方を見る',
@@ -97,25 +94,17 @@ const tints = {
                 <span
                   aria-hidden="true"
                   class:list={[
-                    'flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-2xl',
+                    'flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-transform motion-safe:group-hover:-translate-y-0.5',
                     t.icon,
                   ]}
                 >
-                  {j.emoji}
+                  <JourneyIcon name={j.icon} class="h-6 w-6" />
                 </span>
-                <span
-                  class:list={[
-                    'flex items-center gap-1.5 font-serif text-sm font-medium tracking-wide text-primary-deep',
-                    "before:text-xs before:text-accent-strong before:content-['▲']",
-                  ]}
-                >
-                  {j.label}
-                  {j.featured && (
-                    <span class="rounded-full bg-accent-strong px-2 py-0.5 text-[0.65rem] font-medium text-white">
-                      なかま募集中
-                    </span>
-                  )}
-                </span>
+                {j.featured && (
+                  <span class="rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
+                    なかま募集中
+                  </span>
+                )}
               </div>
               <h3 class="font-serif text-xl font-medium text-primary">
                 {j.title}

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -90,12 +90,7 @@ const tints = {
                 : {})}
               class="flex h-full flex-col gap-3 p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              {j.featured && (
-                <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
-                  なかま募集中
-                </span>
-              )}
-              <h3 class="flex items-center gap-3 font-serif text-xl font-medium text-primary">
+              <div class="flex items-center gap-3">
                 <span
                   aria-hidden="true"
                   class:list={[
@@ -105,8 +100,17 @@ const tints = {
                 >
                   <JourneyIcon name={j.icon} class="h-6 w-6" />
                 </span>
-                {j.title}
-              </h3>
+                <div class="flex flex-col gap-1">
+                  {j.featured && (
+                    <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
+                      なかま募集中
+                    </span>
+                  )}
+                  <h3 class="font-serif text-xl font-medium text-primary">
+                    {j.title}
+                  </h3>
+                </div>
+              </div>
               <p class="grow text-sm leading-relaxed text-body">{j.desc}</p>
               <span
                 class:list={[

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -90,7 +90,12 @@ const tints = {
                 : {})}
               class="flex h-full flex-col gap-3 p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              <div class="flex items-center gap-3">
+              {j.featured && (
+                <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
+                  なかま募集中
+                </span>
+              )}
+              <h3 class="flex items-center gap-3 font-serif text-xl font-medium text-primary">
                 <span
                   aria-hidden="true"
                   class:list={[
@@ -100,13 +105,6 @@ const tints = {
                 >
                   <JourneyIcon name={j.icon} class="h-6 w-6" />
                 </span>
-                {j.featured && (
-                  <span class="rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
-                    なかま募集中
-                  </span>
-                )}
-              </div>
-              <h3 class="font-serif text-xl font-medium text-primary">
                 {j.title}
               </h3>
               <p class="grow text-sm leading-relaxed text-body">{j.desc}</p>

--- a/src/components/JourneyCards.astro
+++ b/src/components/JourneyCards.astro
@@ -90,22 +90,22 @@ const tints = {
                 : {})}
               class="flex h-full flex-col gap-3 p-6 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
             >
-              <div class="flex items-center gap-3">
-                <span
-                  aria-hidden="true"
-                  class:list={[
-                    'flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-transform motion-safe:group-hover:-translate-y-0.5',
-                    t.icon,
-                  ]}
-                >
-                  <JourneyIcon name={j.icon} class="h-6 w-6" />
-                </span>
-                <div class="flex flex-col gap-1">
-                  {j.featured && (
-                    <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white">
-                      なかま募集中
-                    </span>
-                  )}
+              <div class="flex flex-col gap-1">
+                {j.featured && (
+                  <span class="inline-flex w-fit rounded-full bg-accent-strong px-2.5 py-0.5 text-[0.65rem] font-medium tracking-wide text-white ms-15">
+                    なかま募集中
+                  </span>
+                )}
+                <div class="flex items-center gap-3">
+                  <span
+                    aria-hidden="true"
+                    class:list={[
+                      'flex h-12 w-12 shrink-0 items-center justify-center rounded-full transition-transform motion-safe:group-hover:-translate-y-0.5',
+                      t.icon,
+                    ]}
+                  >
+                    <JourneyIcon name={j.icon} class="h-6 w-6" />
+                  </span>
                   <h3 class="font-serif text-xl font-medium text-primary">
                     {j.title}
                   </h3>

--- a/src/components/JourneyIcon.astro
+++ b/src/components/JourneyIcon.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * JourneyIcon — トップの 3 導線カード (JourneyCards) のアイコン (SVG ラインアート)。
+ *
+ * 絵文字 (🌱 / 🍵 / 🤝) は OS・フォントで見えがばらつき、サイトの線画トーン
+ * (ArrowIcon と同じ stroke ベース) から浮いていた。思わず覗きたくなる「次の一歩」を
+ * 表すため、各導線にひとつずつ手描きの線アイコンを用意して統一する。
+ *
+ * - sprout  … 参加する: 双葉の芽。これから一緒に育つ・芽吹くつながりを表す
+ * - cup     … 成果品: 湯気の立つ湯のみ。この土地の味・実りを手に取る楽しみ
+ * - hands   … 支える: 両手にすくった心。離れていても活動を応援できること
+ *
+ * currentColor で囲み円の文字色 (tint) に同調する。viewBox 24・線幅は ArrowIcon と
+ * 揃え、装飾なので aria-hidden。サイズ・配置は呼び出し側が class で渡す。
+ */
+interface Props {
+  name: 'sprout' | 'cup' | 'hands'
+  class?: string
+}
+
+const { name, class: className = '' } = Astro.props
+---
+
+<svg
+  aria-hidden="true"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.7"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class:list={['shrink-0', className]}
+>
+  {
+    name === 'sprout' && (
+      <>
+        {/* 茎 */}
+        <path d="M12 21V10" />
+        {/* 左の葉 (下生え) */}
+        <path d="M12 14C9.5 14 5 13 4.5 9.5 8 9.5 11.5 11 12 14Z" />
+        {/* 右の葉 (上に伸びる) */}
+        <path d="M12 11C12.5 8 16 6.5 19.5 6.5 19 10 15.5 11.5 12 11Z" />
+      </>
+    )
+  }
+  {
+    name === 'cup' && (
+      <>
+        {/* 湯気 */}
+        <path d="M10 3c-1 1-1 2 0 3" />
+        <path d="M14 3c-1 1-1 2 0 3" />
+        {/* 湯のみ本体 */}
+        <path d="M6 9h12v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4Z" />
+        {/* 取っ手 */}
+        <path d="M18 10.5h1.3a2.2 2.2 0 0 1 0 4.4H18" />
+      </>
+    )
+  }
+  {
+    name === 'hands' && (
+      <>
+        {/* 心 (ハート) */}
+        <path d="M12 12s-4.5-2.6-4.5-5.3C7.5 5.3 8.6 4.5 9.8 4.5c1 0 1.8.6 2.2 1.4.4-.8 1.2-1.4 2.2-1.4 1.2 0 2.3.8 2.3 2.2C16.5 9.4 12 12 12 12Z" />
+        {/* すくう両手 */}
+        <path d="M4 15c2 3.6 4.8 5.6 8 5.6s6-2 8-5.6" />
+      </>
+    )
+  }
+</svg>


### PR DESCRIPTION
- 「参加する」など小ラベル (▲付き) はタイトル (例: 活動に参加する) と
  重複していたため削除。featured の「なかま募集中」バッジは維持
- 絵文字アイコン (🌱/🍵/🤝) を JourneyIcon.astro の手描き線アイコン
  (双葉の芽 / 湯気の立つ湯のみ / 心をすくう両手) へ置換し、
  ArrowIcon と同じ stroke トーン・tint 配色に統一。ホバーで軽く浮く演出を追加

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LgFFf5DiyTHQubNGMS3p4R