### PR TITLE
ci: GitHub ネイティブのコードカバレッジ連携を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
       - run: npm ci
       - run: npm run ${{ matrix.task }}
 
-  # テスト + カバレッジ計測。結果を Codecov へ送信する。
-  coverage:
+  # テスト + カバレッジ計測。結果を Codecov へ送信しつつ、後段の coverage
+  # ジョブが GitHub ネイティブのコードカバレッジ (Quality セクション) へ
+  # 反映できるよう、カバレッジレポートをアーティファクトとして公開する。
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -50,6 +52,38 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # success 時のみアーティファクト化 (test が失敗すれば coverage ジョブも走らない)
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/cobertura-coverage.xml
+
+  # GitHub ネイティブのコードカバレッジ (PR の Quality セクション) へ反映する。
+  # 現状この機能は public preview のため、当面は test ジョブの Codecov 連携も併存させる。
+  # test の成功 (needs) を前提に、test が公開したアーティファクトからレポートする。
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+      # push (main) などで PR 番号を逆引きする場合に必要
+      pull-requests: read
+    steps:
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+      - name: Report coverage to GitHub
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: cobertura-coverage.xml
+          language: TypeScript
+          label: code-coverage/vitest
+          # fork PR など権限のない実行ではアクションが gracefully に抜けるが、
+          # 念のためアップロード失敗で CI 全体を落とさない
+          fail-on-error: false
 
   # フルビルド検証。同一リポジトリのブランチ/PR と main への push は Cloudflare の
   # プレビュー/本番ビルドが検証するため、ここでは Cloudflare が自動ビルドしない

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,10 @@ export default getViteConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
-      // Codecov 連携用に lcov を出力。ローカル確認用に text / html も併設。
-      reporter: ['text', 'html', 'lcov'],
+      // Codecov 連携用に lcov、GitHub ネイティブのコードカバレッジ
+      // (Quality セクション) 連携用に cobertura を出力。ローカル確認用に
+      // text / html も併設。
+      reporter: ['text', 'html', 'lcov', 'cobertura'],
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       // テスト本体・型定義・設定ファイル (テスト可能なロジックを持たない) を除外する。


### PR DESCRIPTION
PR の Quality セクションでカバレッジを確認できるよう、coverage ジョブを
test / coverage の 2 段に分割する。

- coverage ジョブを test にリネーム。テスト + カバレッジ計測と Codecov 連携を担い、
  success 時に cobertura レポートをアーティファクト化する。
- 新 coverage ジョブは needs: test でアーティファクトを取得し、
  actions/upload-code-coverage で GitHub ネイティブのコードカバレッジへ反映する。
- GitHub ネイティブ機能は現状 public preview のため Codecov 連携は併存させる。
- vitest に cobertura レポーターを追加 (GitHub は Cobertura XML を要求するため)。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016oecuxAdY8syZoY6stzfBe