### PR TITLE
perf: 非ブロッキングのフォント読み込みと画像圧縮で PageSpeed を改善

### DIFF
--- a/src/components/BlurImage.astro
+++ b/src/components/BlurImage.astro
@@ -29,6 +29,12 @@ interface Props {
    * false にして下絵の上へ即時表示する。
    */
   fade?: boolean
+  /**
+   * webp 出力品質 (0–100)。既定 62。景観・葉物など高詳細な写真でも、Astro 既定の
+   * 高品質 (~80 相当) だと 750px 幅でも 200KiB 超になりモバイル回線で重い。62 なら
+   * 体感差なく 2〜3 割軽くできる。より鮮明さが要る箇所は呼び出し側で上書きする。
+   */
+  quality?: number
   /** ラッパー (形状・余白・アスペクト・枠線など) に付けるクラス */
   class?: string
   /** 本画像 (object-fit やフィルタ) に付けるクラス */
@@ -44,6 +50,7 @@ const {
   decoding = 'async',
   fetchpriority,
   fade = true,
+  quality = 62,
   class: className = '',
   imgClass = '',
 } = Astro.props
@@ -59,6 +66,7 @@ const blur = await getBlurDataURL(src)
     src={src}
     alt={alt}
     sizes={sizes}
+    quality={quality}
     loading={loading}
     decoding={decoding}
     fetchpriority={fetchpriority}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -83,6 +83,11 @@ const structuredData = [
 // GA_MEASUREMENT_ID で設定する。未設定 (ローカル開発・プレビュー) では計測タグを
 // 出力しないため、開発中のアクセスが本番の解析に混ざらない。
 const gaMeasurementId = import.meta.env.GA_MEASUREMENT_ID
+
+// Google Fonts の CSS URL。非ブロッキング読み込み (preload / print swap / noscript) で
+// 複数回参照するため定数化する。要求ウェイトは実使用分のみ (Serif 600 は不使用のため除外)。
+const fontsHref =
+  'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500&family=Noto+Serif+JP:wght@300;500&display=swap'
 ---
 
 <!doctype html>
@@ -127,13 +132,28 @@ gtag('config', '${gaMeasurementId}');`}
         </Fragment>
       )
     }
-    <!-- タイポグラフィ: 見出し Noto Serif JP / 本文 Noto Sans JP (light 基調) -->
+    {
+      /* タイポグラフィ: 見出し Noto Serif JP / 本文 Noto Sans JP (light 基調)。
+        日本語 Web フォントは巨大 (ウェイトごとに ~100 個の unicode-range 分割) で、
+        フォント CSS を render-blocking で読むと FCP/LCP が CSS ダウンロード完了まで
+        待たされる (低速 4G で数秒)。そこで CSS を非ブロッキングに読み込む:
+        まず media="print" で適用対象外として取得し、onload で media を all に戻す。
+        display=swap によりまず system フォント (Hiragino/Yu 系) を即描画し、Web フォントは
+        遅れて差し替える。JS 無効時は noscript の通常 stylesheet でフォールバックする。
+        未使用ウェイト (Serif 600 = font-semibold は不使用) は要求しない。 */
+    }
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preload" as="style" href={fontsHref} />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500&family=Noto+Serif+JP:wght@300;500;600&display=swap"
+      href={fontsHref}
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
+    <noscript>
+      <link href={fontsHref} rel="stylesheet" />
+    </noscript>
   </head>
   <body class={fullscreen ? 'is-fullscreen' : undefined}>
     <SiteHeader currentPath={currentPath} />


### PR DESCRIPTION
PageSpeed Insights (モバイル) のスコア 56 の主因に対処する。

## フォント (最大要因: render-blocking 10,750ms)
日本語 Web フォント (Noto Sans/Serif JP) の CSS を render-blocking の
<link rel="stylesheet"> で読んでいたため、FCP/LCP が CSS ダウンロード完了
(低速 4G で 178KiB / 1.7s) まで待たされ FCP 10.7s / LCP 12.2s になっていた。

- CSS を非ブロッキング化: rel="preload" as="style" で先行取得し、
  media="print" onload="this.media='all'" で描画をブロックせず適用。
  JS 無効時は <noscript> の通常 stylesheet でフォールバック。
- display=swap により system フォント (Hiragino/Yu 系) を即描画し、
  Web フォントは遅れて差し替える。
- 未使用ウェイト Serif 600 (font-semibold は不使用) を要求から削除。

## 画像配信 (削減見込み 342KiB)
Astro の webp 出力が高品質すぎ、750px 幅でも 200KiB 超になっていた。

- BlurImage に quality prop を追加し既定 62 に設定。ヒーロー・近況サムネイル
  など写真全体をカバー。LCP ヒーローは 125→96KiB (-23%)、近況画像も 18-24% 減。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CLGE4zLktivpkUgxu5TmaQ